### PR TITLE
Fixed decoding of sample files with non-LTE rates (6, 7 and 8 MHz)

### DIFF
--- a/src/Phy.h
+++ b/src/Phy.h
@@ -152,6 +152,11 @@ class Phy {
      */
     uint8_t nof_mbsfn_prb() { return _cell.mbsfn_prb; }
 
+    /**
+     * Override number of PRB in MBSFN/PMCH
+     */
+    void set_nof_mbsfn_prb(uint8_t prb) { _cell.mbsfn_prb = prb; }
+
     void set_cell();
 
     typedef struct {


### PR DESCRIPTION
do not readjust the sample rate to that received in the MIB, but stay at the file's rate throughout