### PR TITLE
Add support for AGC via configuration flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+
+#Clion
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project (modem VERSION 1.2.0)
+project (modem VERSION 1.2.1)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/SdrReader.cpp
+++ b/src/SdrReader.cpp
@@ -164,10 +164,11 @@ auto SdrReader::set_gain(bool use_agc, double gain, uint8_t idx) -> bool {
 }
 
 auto SdrReader::tune(uint32_t frequency, uint32_t sample_rate,
-    uint32_t bandwidth, double gain, const std::string& antenna) -> bool {
+    uint32_t bandwidth, double gain, const std::string& antenna, bool use_agc) -> bool {
   _frequency = frequency;
   _filterBw = bandwidth;
   _sampleRate = sample_rate;
+  _use_agc = use_agc;
 
   init_buffer();
 

--- a/src/SdrReader.cpp
+++ b/src/SdrReader.cpp
@@ -180,8 +180,8 @@ auto SdrReader::tune(uint32_t frequency, uint32_t sample_rate,
     return false;
   }
 
-  spdlog::info("Tuning to {} MHz, filter bandwidth {} MHz, sample rate {}, gain {}, antenna path {}",
-      frequency/1000000.0, bandwidth/1000000.0, sample_rate/1000000.0, gain, antenna);
+  spdlog::info("Tuning to {} MHz, filter bandwidth {} MHz, sample rate {}, gain {}, antenna path {} with AGC set to {}",
+      frequency/1000000.0, bandwidth/1000000.0, sample_rate/1000000.0, gain, antenna, use_agc);
 
   auto sdr = (SoapySDR::Device*)_sdr;
 

--- a/src/SdrReader.h
+++ b/src/SdrReader.h
@@ -35,18 +35,14 @@
  *  the received samples.
  */
 class SdrReader {
- public:
+public:
     /**
      *  Default constructor.
      *
      *  @param cfg Config singleton reference
      */
-    explicit SdrReader(const libconfig::Config& cfg, size_t rx_channels)
-      : _overflows(0)
-      , _underflows(0)
-      , _cfg(cfg)
-      , _rx_channels(rx_channels)
-      , _readerThread{} {}
+    explicit SdrReader(const libconfig::Config &cfg, size_t rx_channels)
+            : _overflows(0), _underflows(0), _cfg(cfg), _rx_channels(rx_channels), _readerThread{} {}
 
     /**
      *  Default destructor.
@@ -61,12 +57,13 @@ class SdrReader {
     /**
      * Initializes the SDR interface and creates a ring buffer according to the params from Cfg.
      */
-    bool init(const std::string& device_args, const char* sample_file, const char* write_sample_file);
+    bool init(const std::string &device_args, const char *sample_file, const char *write_sample_file);
 
     /**
      * Tune the SDR to the desired frequency, and set gain, filter and antenna parameters.
      */
-    bool tune(uint32_t frequency, uint32_t sample_rate, uint32_t bandwidth, double gain, const std::string& antenna);
+    bool tune(uint32_t frequency, uint32_t sample_rate, uint32_t bandwidth, double gain, const std::string &antenna,
+              bool use_agc);
 
     /**
      * Start reading samples from the SDR
@@ -90,7 +87,7 @@ class SdrReader {
      * @param nsamples sample count
      * @param rx_time unused
      */
-    int get_samples(cf_t* data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, srsran_timestamp_t* rx_time);
+    int get_samples(cf_t *data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, srsran_timestamp_t *rx_time);
 
     /**
      * Get current sample rate
@@ -128,6 +125,7 @@ class SdrReader {
     uint32_t rssi() { return _rssi; }
 
     double min_gain() { return _min_gain; }
+
     double max_gain() { return _max_gain; }
 
     /**
@@ -140,18 +138,25 @@ class SdrReader {
      */
     void disableSampleFileWriting() { _write_samples = false; }
 
- private:
+private:
     void init_buffer();
-    bool set_gain(bool use_agc, double gain, uint8_t idx);
-    bool set_sample_rate(uint32_t rate, uint8_t idx);
-    bool set_filter_bw(uint32_t bandwidth, uint8_t idx);
-    bool set_antenna(const std::string& antenna, uint8_t idx);
-    bool set_frequency(uint32_t frequency, uint8_t idx);
-    void read();
-    void* _sdr = nullptr;
-    void* _stream = nullptr;
 
-    const libconfig::Config& _cfg;
+    bool set_gain(bool use_agc, double gain, uint8_t idx);
+
+    bool set_sample_rate(uint32_t rate, uint8_t idx);
+
+    bool set_filter_bw(uint32_t bandwidth, uint8_t idx);
+
+    bool set_antenna(const std::string &antenna, uint8_t idx);
+
+    bool set_frequency(uint32_t frequency, uint8_t idx);
+
+    void read();
+
+    void *_sdr = nullptr;
+    void *_stream = nullptr;
+
+    const libconfig::Config &_cfg;
 
     std::unique_ptr<MultichannelRingbuffer> _buffer;
 
@@ -163,16 +168,17 @@ class SdrReader {
     double _frequency;
     unsigned _filterBw;
     double _gain;
+    bool _use_agc;
     double _min_gain;
     double _max_gain;
     std::string _antenna;
     unsigned _overflows;
     unsigned _underflows;
 
-    cf_t* _read_buffer;
+    cf_t *_read_buffer;
 
-    srsran_filesource_t          file_source;
-    srsran_filesink_t          file_sink;
+    srsran_filesource_t file_source;
+    srsran_filesink_t file_sink;
 
     std::chrono::steady_clock::time_point _last_read;
 
@@ -191,6 +197,4 @@ class SdrReader {
     std::string _temp_sensor_key = {};
 
     std::map<std::string, std::string> _device_args;
-
-    bool _use_agc = false;
 };

--- a/supporting_files/5gmag-rt.conf
+++ b/supporting_files/5gmag-rt.conf
@@ -5,6 +5,7 @@ modem: {
     search_sample_rate =    7680000;
 
     normalized_gain = 40.0;
+    use_agc = false;
     device_args = "driver=lime";
     antenna = "LNAW";
     rx_channels = 1;


### PR DESCRIPTION
This PR addresses #28 and enables automatic gain control configuration for the SDR reader via the configuration file