### PR TITLE
rt-mbms-modem release 16 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docs
 
 # cmake build directory
 build
+build*
 cmake-build-debug
 
 # VIM files

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/srsran"]
 	path = lib/srsran
-	url = ../srsRAN
+	url = ../srsRAN_4G
 	branch = fembms
 [submodule "supporting_files/rt-common-shared"]
 	path = supporting_files/rt-common-shared

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ link_directories(
     ${PROJECT_BINARY_DIR}/lib/srsran/lib/src/phy/
     )
 
-set(CMAKE_CXX_CLANG_TIDY clang-tidy --format-style=google --checks=clang-diagnostic-*,clang-analyzer-*,-*,bugprone*,modernize*,performance*)
+set(CMAKE_CXX_CLANG_TIDY clang-tidy --format-style=google --checks=clang-diagnostic-*,clang-analyzer-*,-*,bugprone*,modernize*,-modernize-use-scoped-lock,performance*)
 
 add_executable(modem src/main.cpp src/SdrReader.cpp src/Phy.cpp
   src/CasFrameProcessor.cpp src/MbsfnFrameProcessor.cpp src/Rrc.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ link_directories(
     ${PROJECT_BINARY_DIR}/lib/srsran/lib/src/phy/
     )
 
-set(CMAKE_CXX_CLANG_TIDY clang-tidy --format-style=google --checks=clang-diagnostic-*,clang-analyzer-*,-*,bugprone*,modernize*,-modernize-use-scoped-lock,performance*)
+set(CMAKE_CXX_CLANG_TIDY clang-tidy --format-style=google --checks=clang-diagnostic-*,clang-analyzer-*,-*,bugprone*,-bugprone-easily-swappable-parameters,modernize*,-modernize-use-scoped-lock,-modernize-use-trailing-return-type,performance*)
 
 add_executable(modem src/main.cpp src/SdrReader.cpp src/Phy.cpp
   src/CasFrameProcessor.cpp src/MbsfnFrameProcessor.cpp src/Rrc.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project (modem VERSION 1.2.2)
+project (modem VERSION 1.3.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -72,7 +72,7 @@ target_compile_options(modem PRIVATE
 )
 
 target_link_options(modem PRIVATE
-  # -fsanitize=address
+  #-fsanitize=address
   #-fsanitize=undefined
   #-fsanitize=leak
   #-fsanitize=thread

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,13 @@ include(FindPkgConfig)
 
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/lib/include)
 
-include_directories(
+include_directories(BEFORE PRIVATE
     "${PROJECT_BINARY_DIR}"
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/src
-
+    #    )
     SYSTEM
+    #target_include_directories(modem SYSTEM PRIVATE 
     ${PROJECT_SOURCE_DIR}/lib/srsran
     ${PROJECT_SOURCE_DIR}/lib/srsran/lib/include
     ${PROJECT_BINARY_DIR}/lib/srsran/lib/include
@@ -24,16 +25,17 @@ include_directories(
     ${LIB_LIMESUITE_INCLUDE_DIRS}
     )
 
+
 set(ENABLE_SRSUE OFF CACHE BOOL "Build srsUE application")
 set(ENABLE_SRSENB OFF CACHE BOOL "Build srsENB application")
 set(ENABLE_SRSEPC OFF CACHE BOOL "Build srsEPC application")
 add_subdirectory(lib/srsran)
 
 find_package(cpprestsdk REQUIRED)
-include_directories(
-  SYSTEM
-    ${SPDLOG_INCLUDEDIR}
-    )
+#include_directories(
+# SYSTEM
+#    ${SPDLOG_INCLUDEDIR}
+#    )
 
 configure_file("include/Version.h.in" "Version.h")
 
@@ -42,15 +44,46 @@ link_directories(
     ${PROJECT_BINARY_DIR}/lib/srsran/lib/src/phy/
     )
 
-
 set(CMAKE_CXX_CLANG_TIDY clang-tidy --format-style=google --checks=clang-diagnostic-*,clang-analyzer-*,-*,bugprone*,modernize*,performance*)
 
 add_executable(modem src/main.cpp src/SdrReader.cpp src/Phy.cpp
   src/CasFrameProcessor.cpp src/MbsfnFrameProcessor.cpp src/Rrc.cpp
   src/Gw.cpp src/RestHandler.cpp src/MeasurementFileWriter.cpp src/MultichannelRingbuffer.cpp)
 
+add_library(project_warnings INTERFACE)
+
+target_compile_options(project_warnings INTERFACE
+  -Wall
+  -Wextra
+  -Wpedantic
+  -Werror
+  )
+
+target_compile_options(modem PRIVATE
+  #-fsanitize=address
+  #-fsanitize=undefined
+  #-fsanitize=leak
+  #-fsanitize=thread
+  #-flto
+  #-fvisibility=default
+  #-fsanitize=cfi
+  -fno-omit-frame-pointer
+  -g
+)
+
+target_link_options(modem PRIVATE
+  # -fsanitize=address
+  #-fsanitize=undefined
+  #-fsanitize=leak
+  #-fsanitize=thread
+  #-flto
+  #-fvisibility=default
+  #-fsanitize=cfi
+)
+
 target_link_libraries( modem
     LINK_PUBLIC
+    #    spdlog
     srsran_phy
     srsran_mac
     srsran_rlc
@@ -65,6 +98,7 @@ target_link_libraries( modem
     SoapySDR
 )
 
+target_link_libraries(modem PRIVATE project_warnings)
 
 install(TARGETS modem)
 install(FILES supporting_files/5gmag-rt-modem.service DESTINATION /usr/lib/systemd/system)

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -14,7 +14,7 @@ struct SPDLOG_API log_msg
     log_msg(log_clock::time_point log_time, source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(string_view_t logger_name, level::level_enum lvl, string_view_t msg);
-    log_msg(const log_msg &other) = default;
+//    log_msg(const log_msg &other) = default;
 
     string_view_t logger_name;
     level::level_enum level{level::off};

--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -3940,10 +3940,10 @@ FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
     fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_arg<char> operator"" _a(const char* s, size_t) {
+FMT_CONSTEXPR detail::udl_arg<char> operator""_a(const char* s, size_t) {
   return {s};
 }
-FMT_CONSTEXPR detail::udl_arg<wchar_t> operator"" _a(const wchar_t* s, size_t) {
+FMT_CONSTEXPR detail::udl_arg<wchar_t> operator""_a(const wchar_t* s, size_t) {
   return {s};
 }
 }  // namespace literals

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -54,7 +54,7 @@ public:
 	template <class Func, class... Args>
 	auto push(Func &&fn, Args &&...args)
 	{
-		using return_type = typename std::result_of<Func(Args...)>::type;
+		using return_type = typename std::invoke_result<Func, Args...>::type;
 
 		auto task{ std::make_shared<std::packaged_task<return_type()>>(
 			std::bind(std::forward<Func>(fn), std::forward<Args>(args)...)

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -45,10 +45,10 @@ public:
 	}
 
 	thread_pool(thread_pool const &) = delete;
-	thread_pool(thread_pool &&) = default;
+//	thread_pool(thread_pool &&) = default;
 
 	thread_pool &operator=(thread_pool const &) = delete;
-	thread_pool &operator=(thread_pool &&) = default;
+//	thread_pool &operator=(thread_pool &&) = default;
 
 	// Push a new task into the queue
 	template <class Func, class... Args>

--- a/src/CasFrameProcessor.cpp
+++ b/src/CasFrameProcessor.cpp
@@ -24,7 +24,7 @@
 auto CasFrameProcessor::init() -> bool {
   _signal_buffer_max_samples = 3 * SRSRAN_SF_LEN_PRB(MAX_PRB);
 
-  for (auto ch = 0; ch < _rx_channels; ch++) {
+  for (size_t ch = 0; ch < _rx_channels; ch++) {
     _signal_buffer_rx[ch] = srsran_vec_cf_malloc(_signal_buffer_max_samples);
     if (!_signal_buffer_rx[ch]) {
       spdlog::error("Could not allocate regular DL signal buffer\n");
@@ -73,6 +73,12 @@ auto CasFrameProcessor::init() -> bool {
 
 CasFrameProcessor::~CasFrameProcessor() {
   for (auto & i : _data) {
+    if (i) {
+      free(i);
+    }
+  }
+
+  for (auto & i : _signal_buffer_rx) {
     if (i) {
       free(i);
     }
@@ -138,7 +144,7 @@ auto CasFrameProcessor::process(uint32_t tti) -> bool {
     }
 
     _rest._pdsch.SetData(pdsch_data());
-    _rest._ce_values    = std::move(ce_values());
+    _rest._ce_values    = (ce_values());
 
     // Decode PDSCH..
     auto ret = srsran_ue_dl_decode_pdsch(&_ue_dl, &_sf_cfg, &_ue_dl_cfg.cfg.pdsch, pdsch_res);

--- a/src/CasFrameProcessor.h
+++ b/src/CasFrameProcessor.h
@@ -44,9 +44,9 @@ class CasFrameProcessor {
     *  @param rlc RLC reference
     *  @param rest RESTful API handler reference
     */
-   CasFrameProcessor(const libconfig::Config& cfg, Phy& phy, srsran::rlc& rlc, RestHandler& rest, unsigned rx_channels)
-     : _cfg(cfg)
-     , _phy(phy)
+   CasFrameProcessor(/*const libconfig::Config& cfg,*/ Phy& phy, srsran::rlc& rlc, RestHandler& rest, unsigned rx_channels)
+     :/* _cfg(cfg)
+     ,*/ _phy(phy)
      , _rest(rest)
      , _rlc(rlc)
      , _rx_channels(rx_channels)
@@ -172,10 +172,10 @@ class CasFrameProcessor {
    bool inline is_started() { return _started; }
 
  private:
-   const libconfig::Config& _cfg;
-    srsran::rlc& _rlc;
+//   const libconfig::Config& _cfg;
     Phy& _phy;
     RestHandler& _rest;
+    srsran::rlc& _rlc;
 
     cf_t*    _signal_buffer_rx[SRSRAN_MAX_PORTS] = {};
     uint32_t _signal_buffer_max_samples          = 0;

--- a/src/Gw.cpp
+++ b/src/Gw.cpp
@@ -43,7 +43,7 @@ void Gw::write_pdu_mch(uint32_t mch_idx, uint32_t lcid, srsran::unique_byte_buff
     } else {
       auto ip_hdr = reinterpret_cast<iphdr*>(pdu->msg);
       if (ip_hdr->protocol == 17 /*UDP*/) {
-        auto udp_hdr = reinterpret_cast<udphdr*>(pdu->msg + 4U * ip_hdr->ihl);
+        auto udp_hdr = reinterpret_cast<udphdr*>(pdu->msg + static_cast<size_t>(4U) * ip_hdr->ihl);
         char dest[INET6_ADDRSTRLEN] = "";   // NOLINT
         inet_ntop(AF_INET, (const void*)&ip_hdr->daddr, dest, sizeof(dest));
 

--- a/src/Gw.cpp
+++ b/src/Gw.cpp
@@ -73,6 +73,7 @@ void Gw::write_pdu_mch(uint32_t mch_idx, uint32_t lcid, srsran::unique_byte_buff
       }
 
       _wr_mutex.lock();
+//      spdlog::info("GW write: {} bytes to TUN", pdu->N_bytes);
       int n = write(_tun_fd, pdu->msg, pdu->N_bytes);
       _wr_mutex.unlock();
 

--- a/src/Gw.h
+++ b/src/Gw.h
@@ -41,9 +41,9 @@ class Gw : public srsue::gw_interface_stack {
      *  @param cfg Config singleton reference
      *  @param phy PHY reference
      */
-    Gw(const libconfig::Config& cfg, Phy& phy)
-      : _cfg(cfg)
-        , _phy(phy)
+    Gw(/*const libconfig::Config& cfg,*/ Phy& phy)
+      :/* _cfg(cfg)
+        ,*/ _phy(phy)
       {}
 
     /**
@@ -63,16 +63,16 @@ class Gw : public srsue::gw_interface_stack {
     void write_pdu_mch(uint32_t mch_idx, uint32_t lcid, srsran::unique_byte_buffer_t pdu) override;
 
     // Unused interface methods
-    void add_mch_port(uint32_t lcid, uint32_t port) override {};
-    void write_pdu(uint32_t lcid, srsran::unique_byte_buffer_t pdu) override {};
-    int setup_if_addr(uint32_t lcid, uint8_t pdn_type, uint32_t ip_addr, uint8_t* ipv6_if_id, char* err_str) override { return -1; };
-    int apply_traffic_flow_template(const uint8_t& eps_bearer_id, const LIBLTE_MME_TRAFFIC_FLOW_TEMPLATE_STRUCT* tft) override { return -1; };
-    void set_test_loop_mode(const test_loop_mode_state_t mode, const uint32_t ip_pdu_delay_ms = 0) override {};
+    void add_mch_port([[maybe_unused]] uint32_t lcid, [[maybe_unused]] uint32_t port) override {};
+    void write_pdu([[maybe_unused]] uint32_t lcid, [[maybe_unused]] srsran::unique_byte_buffer_t pdu) override {};
+    int setup_if_addr([[maybe_unused]] uint32_t lcid, [[maybe_unused]] uint8_t pdn_type, [[maybe_unused]] uint32_t ip_addr, [[maybe_unused]] uint8_t* ipv6_if_id, [[maybe_unused]] char* err_str) override { return -1; };
+    int apply_traffic_flow_template([[maybe_unused]] const uint8_t& eps_bearer_id, [[maybe_unused]] const LIBLTE_MME_TRAFFIC_FLOW_TEMPLATE_STRUCT* tft) override { return -1; };
+    void set_test_loop_mode([[maybe_unused]] const test_loop_mode_state_t mode, [[maybe_unused]] const uint32_t ip_pdu_delay_ms = 0) override {};
 
-    int deactivate_eps_bearer(const uint32_t eps_bearer_id) override {return 0;};
+    int deactivate_eps_bearer([[maybe_unused]] const uint32_t eps_bearer_id) override {return 0;};
     bool is_running() override { return true; };
   private:
-    const libconfig::Config& _cfg;
+//    const libconfig::Config& _cfg;
 
     std::mutex _wr_mutex;
     int32_t _tun_fd = -1;

--- a/src/MbsfnFrameProcessor.cpp
+++ b/src/MbsfnFrameProcessor.cpp
@@ -28,7 +28,7 @@ std::mutex MbsfnFrameProcessor::_rlc_mutex;
 auto MbsfnFrameProcessor::init() -> bool {
   _signal_buffer_max_samples = 3 * SRSRAN_SF_LEN_PRB(MAX_PRB);
 
-  for (auto ch = 0; ch < _rx_channels; ch++) {
+  for (size_t ch = 0; ch < _rx_channels; ch++) {
     _signal_buffer_rx[ch] = srsran_vec_cf_malloc(_signal_buffer_max_samples);
     if (!_signal_buffer_rx[ch]) {
       spdlog::error("Could not allocate regular DL signal buffer\n");
@@ -71,6 +71,11 @@ auto MbsfnFrameProcessor::init() -> bool {
 }
 
 MbsfnFrameProcessor::~MbsfnFrameProcessor() {
+  for (auto & i : _signal_buffer_rx) {
+    if (i) {
+      free(i);
+    }
+  }
   srsran_softbuffer_rx_free(&_softbuffer);
   srsran_ue_dl_free(&_ue_dl);
 }
@@ -81,7 +86,13 @@ void MbsfnFrameProcessor::set_cell(srsran_cell_t cell) {
 }
 
 auto MbsfnFrameProcessor::process(uint32_t tti) -> int {
-  spdlog::trace("Processing MBSFN TTI {}", tti);
+
+
+  auto t1 = std::chrono::high_resolution_clock::now();
+  auto t2 = t1;
+
+  //_mutex.lock();
+  spdlog::debug("Processing MBSFN TTI {}, id {}", tti, id);
 
   uint32_t sfn = tti / 10;
   uint8_t sf = tti % 10;
@@ -99,24 +110,28 @@ auto MbsfnFrameProcessor::process(uint32_t tti) -> int {
 
   if (!mbsfn_cfg.enable) {
     spdlog::trace("PMCH: tti {}: neither MCCH nor MCH enabled. Skipping subframe");
-    _mutex.unlock();
+   // _mutex.unlock();
     return -1;
   }
 
   if (mbsfn_cfg.is_mcch) {
-    _rest._mcch.total++;
+    //_rest._mcch.total++;
+    _rest._mcch.add_total();
   } else {
-    _rest._mch[mch_idx].total++;
+    //_rest._mch[mch_idx].total++;
+    _rest._mch[mch_idx].add_total();
   }
 
   if (srsran_ue_dl_decode_fft_estimate(&_ue_dl, &_sf_cfg, &_ue_dl_cfg) < 0) {
     if (mbsfn_cfg.is_mcch) {
-      _rest._mcch.errors++;
+      //_rest._mcch.errors++;
+      _rest._mcch.add_error();
     } else {
-      _rest._mch[mch_idx].errors++;
+      //_rest._mch[mch_idx].errors++;
+      _rest._mch[mch_idx].add_error();
     }
     spdlog::error("Getting PDCCH FFT estimate");
-    _mutex.unlock();
+    //_mutex.unlock();
     return -1;
   }
 
@@ -134,12 +149,14 @@ auto MbsfnFrameProcessor::process(uint32_t tti) -> int {
 
   if (srsran_ue_dl_decode_pmch(&_ue_dl, &_sf_cfg, &_pmch_cfg, &pmch_dec) != 0) {
     if (mbsfn_cfg.is_mcch) {
-      _rest._mcch.errors++;
+      //_rest._mcch.errors++;
+      _rest._mcch.add_error();
     } else {
-      _rest._mch[mch_idx].errors++;
+      //_rest._mch[mch_idx].errors++;
+      _rest._mch[mch_idx].add_error();
     }
     spdlog::warn("Error decoding PMCH");
-    _mutex.unlock();
+    //_mutex.unlock();
     return -1;
   }
 
@@ -182,11 +199,13 @@ auto MbsfnFrameProcessor::process(uint32_t tti) -> int {
         if (lcid >= SRSRAN_N_MCH_LCIDS) {
           spdlog::warn("Radio bearer id must be in [0:%d] - %d", SRSRAN_N_MCH_LCIDS, lcid);
           if (mbsfn_cfg.is_mcch) {
-            _rest._mcch.errors++;
+            //_rest._mcch.errors++;
+            _rest._mcch.add_error();
           } else {
-            _rest._mch[mch_idx].errors++;
+            //_rest._mch[mch_idx].errors++;
+            _rest._mch[mch_idx].add_error();
           }
-          _mutex.unlock();
+          //_mutex.unlock();
           return -1;
         }
 
@@ -199,13 +218,15 @@ auto MbsfnFrameProcessor::process(uint32_t tti) -> int {
     }
   } else {
     if (mbsfn_cfg.is_mcch) {
-      _rest._mcch.errors++;
+      //_rest._mcch.errors++;
+      _rest._mcch.add_error();
     } else {
-      _rest._mch[mch_idx].errors++;
+      //_rest._mch[mch_idx].errors++;
+      _rest._mch[mch_idx].add_error();
     }
 
     spdlog::trace("PMCH in TTI {} failed with CRC error", tti);
-    _mutex.unlock();
+    //_mutex.unlock();
     return -1;
   }
 
@@ -239,7 +260,10 @@ auto MbsfnFrameProcessor::process(uint32_t tti) -> int {
     _rlc.stop_mch(0, 0);
     _rest._mcch.present = true;
   }
-  _mutex.unlock();
+  //_mutex.unlock();
+
+  t2 = std::chrono::high_resolution_clock::now();
+  //spdlog::info("Time spend processing MBSFN {} microseconds.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
   return mbsfn_cfg.is_mcch ? 0 : 1;
 }
 
@@ -255,5 +279,5 @@ void MbsfnFrameProcessor::configure_mbsfn(uint8_t area_id, srsran_scs_t subcarri
 
 auto MbsfnFrameProcessor::mch_data() const -> std::vector<uint8_t> const {
   const uint8_t* data = reinterpret_cast<uint8_t*>(_ue_dl.pmch.d);
-  return std::move(std::vector<uint8_t>( data, data + _pmch_cfg.pdsch_cfg.grant.nof_re * sizeof(cf_t)));
+  return (std::vector<uint8_t>( data, data + _pmch_cfg.pdsch_cfg.grant.nof_re * sizeof(cf_t)));
 }

--- a/src/MbsfnFrameProcessor.h
+++ b/src/MbsfnFrameProcessor.h
@@ -32,6 +32,11 @@
 #include "Phy.h"
 #include "RestHandler.h"
 
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+
 /**
  *  Frame processor for MBSFN subframes. Handles the complete processing chain for
  *  a CAS subframe: calls FFT and channel estimation, decodes PDSCH and passes received PDUs to RLC.
@@ -48,8 +53,8 @@ class MbsfnFrameProcessor {
      *  @param rest RESTful API handler reference
      */
     MbsfnFrameProcessor(const libconfig::Config& cfg, srsran::rlc& rlc, Phy& phy, srslog::basic_logger& log_h, RestHandler& rest, unsigned rx_channels )
-      : _cfg(cfg)
-      , _rlc(rlc)
+      : /*_cfg(cfg)
+      , */_rlc(rlc)
       , _phy(phy)
       , _rest(rest)
       , mch_mac_msg(20, log_h)
@@ -57,6 +62,7 @@ class MbsfnFrameProcessor {
       {
         _allow_rrc_sn_across_periods = false;
         cfg.lookupValue("modem.phy.allow_rrc_sn_across_periods", _allow_rrc_sn_across_periods); 
+        id = lastid++;
       }
 
     /**
@@ -93,7 +99,18 @@ class MbsfnFrameProcessor {
      *  If process() is not called by the application after calling this method, it must unlock the 
      *  processor itself by calling unlock()
      */
-    cf_t** get_rx_buffer_and_lock() { _mutex.lock(); return _signal_buffer_rx; }
+    cf_t** get_rx_buffer() { 
+      //_mutex.lock(); 
+      //return _signal_buffer_rx; 
+    //  auto t0 = std::chrono::high_resolution_clock::now();
+   /*   _mutex.lock();
+    //  printf("lock waited %ld us\n", std::chrono::high_resolution_clock::now()-t0);
+      return _signal_buffer_rx;
+*/
+//      if (_mutex.try_lock())
+        return _signal_buffer_rx;
+//      return nullptr;
+    }
 
     /**
      *  Size of the signal buffer
@@ -134,8 +151,11 @@ class MbsfnFrameProcessor {
      */
     float cinr_db() { return _ue_dl.chest_res.snr_db; }
 
+    int get_id() { return id; }
+//    std::atomic<bool> busy{false};
+//    void release() { busy.store(false, std::memory_order_release); }
   private:
-    const libconfig::Config& _cfg;
+//    const libconfig::Config& _cfg;
     srsran::rlc& _rlc;
     Phy& _phy;
 
@@ -156,10 +176,10 @@ class MbsfnFrameProcessor {
     uint8_t _area_id = 1;
     bool _mbsfn_configured = false;
 
+    RestHandler& _rest;
+
     srsran::mch_pdu mch_mac_msg;
     std::mutex _mutex;
-
-    RestHandler& _rest;
 
     unsigned _rx_channels;
 
@@ -169,4 +189,33 @@ class MbsfnFrameProcessor {
 
     static std::mutex _rlc_mutex;
     static int _current_mcs;
+
+    inline static int lastid = 0; 
+    int id;
+};
+
+class ProcessorQueue {
+  public:
+    void push(MbsfnFrameProcessor* p) {
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        q.push(p);
+      }
+      cv.notify_one();
+    }
+
+
+    MbsfnFrameProcessor* pop() {
+      std::unique_lock<std::mutex> lock(mutex);
+      
+      cv.wait(lock, [&] { return !q.empty(); });
+      auto p = q.front();
+      q.pop();
+      return p;
+    }
+
+  private:
+    std::queue<MbsfnFrameProcessor*> q;
+    std::mutex mutex;
+    std::condition_variable cv;
 };

--- a/src/MeasurementFileWriter.cpp
+++ b/src/MeasurementFileWriter.cpp
@@ -60,7 +60,9 @@ MeasurementFileWriter::MeasurementFileWriter(const libconfig::Config& cfg)
 
 MeasurementFileWriter::~MeasurementFileWriter() {
   _running = false;
-  _gps_reader_thread.join();
+  if (_gps_reader_thread.joinable()) {
+    _gps_reader_thread.join();
+  }
 }
 
 void MeasurementFileWriter::ReadGps() {

--- a/src/MultichannelRingbuffer.cpp
+++ b/src/MultichannelRingbuffer.cpp
@@ -25,10 +25,10 @@
 MultichannelRingbuffer::MultichannelRingbuffer(size_t size, size_t channels)
   : _size( size )
   , _channels( channels )
-  , _used( 0 )
   , _head( 0 )
+  , _used( 0 )
 {
-  for (auto ch = 0; ch < _channels; ch++) {
+  for (size_t ch = 0; ch < _channels; ch++) {
     auto buf = (char*)srsran_vec_malloc( _size);
     //auto buf = (char*)malloc(_size);
     if (buf == nullptr) {
@@ -36,7 +36,7 @@ MultichannelRingbuffer::MultichannelRingbuffer(size_t size, size_t channels)
     }
     _buffers.push_back(buf);
   }
-  spdlog::debug("Created {}-channel ringbuffer with size {}", _channels, _size );
+  spdlog::info("Created {}-channel ringbuffer with size {}", _channels, _size );
 }
 
 MultichannelRingbuffer::~MultichannelRingbuffer()
@@ -51,7 +51,7 @@ auto MultichannelRingbuffer::read_head() -> std::vector<void*>
 //  _mutex.lock();
   std::lock_guard<std::mutex> lock(_mutex);
   std::vector<void*> buffers(_channels, nullptr);
-  for (auto ch = 0; ch < _channels; ch++) {
+  for (size_t ch = 0; ch < _channels; ch++) {
     buffers[ch] = (void*)(_buffers[ch]); // Return the beggining of the buffer;
   }
   _head = 0;
@@ -73,7 +73,7 @@ auto MultichannelRingbuffer::write_head(size_t* writeable) -> std::vector<void*>
     } else {
       *writeable = _size - tail;
     }
-    for (auto ch = 0; ch < _channels; ch++) {
+    for (size_t ch = 0; ch < _channels; ch++) {
       buffers[ch] = (void*)(_buffers[ch] + tail);
     }
   }
@@ -83,7 +83,7 @@ auto MultichannelRingbuffer::write_head(size_t* writeable) -> std::vector<void*>
 
 auto MultichannelRingbuffer::commit(size_t written) -> void
 {
-  assert(written >= 0);
+  //assert(written >= 0);
   assert(written <= free_size());
   std::lock_guard<std::mutex> lock(_mutex);
   _used += written;
@@ -94,7 +94,7 @@ auto MultichannelRingbuffer::read(std::vector<char*> dest, size_t size) -> void
 {
   assert(dest.size() >= _channels);
   assert(size <= used_size());
-  assert(size >= 0);
+ // assert(size >= 0);
 
   std::lock_guard<std::mutex> lock(_mutex);
   auto end = (_head + size) % _size;
@@ -102,12 +102,12 @@ auto MultichannelRingbuffer::read(std::vector<char*> dest, size_t size) -> void
   if (end <= _head) {
     auto first_part = _size - _head;
     auto second_part = size - first_part;
-    for (auto ch = 0; ch < _channels; ch++) {
+    for (size_t ch = 0; ch < _channels; ch++) {
       memcpy(dest[ch],              _buffers[ch] + _head, first_part);
       memcpy(dest[ch] + first_part, _buffers[ch],         second_part);
     }
   } else {
-    for (auto ch = 0; ch < _channels; ch++) {
+    for (size_t ch = 0; ch < _channels; ch++) {
       memcpy(dest[ch], _buffers[ch] + _head, size);
     }
   }

--- a/src/Phy.cpp
+++ b/src/Phy.cpp
@@ -256,7 +256,7 @@ void Phy::set_mch_scheduling_info(const srsran::sib13_t& sib13) {
   if (sib13.nof_mbsfn_area_info > 0) {
     _sib13 = sib13;
 
-    bzero(&_mcch_table[0], sizeof(uint8_t) * 10);
+    memset(&_mcch_table[0], 0, sizeof(uint8_t) * 10);
     if (sib13.mbsfn_area_info_list[0].mcch_cfg.sf_alloc_info_is_r16) {
       generate_mcch_table_r16(
           &_mcch_table[0],

--- a/src/Phy.cpp
+++ b/src/Phy.cpp
@@ -130,13 +130,15 @@ auto Phy::cell_search() -> bool {
 
   // Try to decode MIB-MBMS
   new_cell.mbms_dedicated = true;
-  new_cell.is_mbms_r16 = false;
   if (srsran_ue_mib_sync_set_cell_prb(&_mib_sync, new_cell, _cs_nof_prb) != 0) {
     spdlog::error("Phy: Error setting UE MIB sync cell");
     return false;
   }
   srsran_ue_sync_reset(&_mib_sync.ue_sync);
   ret = srsran_ue_mib_sync_decode_prb(&_mib_sync, kMaxFramesTimeout, bch_payload.data(), &new_cell.nof_ports, &sfn_offset, _cs_nof_prb);
+
+  spdlog::info("Rel-16 PBCH repetition detected: {}", _mib_sync.ue_mib.pbch.cell.is_mbms_r16);
+  new_cell.is_mbms_r16 = _mib_sync.ue_mib.pbch.cell.is_mbms_r16;
 
   if (!ret) { // MIB-MBMS failed, try to decode regular MIB
   //  init();
@@ -257,11 +259,16 @@ void Phy::set_mch_scheduling_info(const srsran::sib13_t& sib13) {
           &_mcch_table[0],
           static_cast<uint32_t>(
             sib13.mbsfn_area_info_list[0].mcch_cfg.sf_alloc_info));
+
+//      spdlog::info("Rel-16 MBSFN {}", sib13.mbsfn_area_info_list[0].mcch_cfg.sf_alloc_info_is_r16);
+
+
     } else {
       generate_mcch_table(
           &_mcch_table[0],
           static_cast<uint32_t>(
             sib13.mbsfn_area_info_list[0].mcch_cfg.sf_alloc_info));
+//      spdlog::info("Non Rel-16 MBSFN {}", sib13.mbsfn_area_info_list[0].mcch_cfg.sf_alloc_info_is_r16);
     }
 
     std::stringstream ss;

--- a/src/Phy.cpp
+++ b/src/Phy.cpp
@@ -130,6 +130,7 @@ auto Phy::cell_search() -> bool {
 
   // Try to decode MIB-MBMS
   new_cell.mbms_dedicated = true;
+  new_cell.is_mbms_r16 = false;
   if (srsran_ue_mib_sync_set_cell_prb(&_mib_sync, new_cell, _cs_nof_prb) != 0) {
     spdlog::error("Phy: Error setting UE MIB sync cell");
     return false;
@@ -346,6 +347,7 @@ auto Phy::mbsfn_config_for_tti(uint32_t tti, unsigned& area)
 
   if (!_mcch_configured) {
     {
+      spdlog::debug("MCCH not configured tti= {}",  tti);
       return cfg;
     }
   }

--- a/src/Phy.cpp
+++ b/src/Phy.cpp
@@ -32,7 +32,7 @@ static auto receive_callback(void* obj, cf_t* data[SRSRAN_MAX_CHANNELS],        
   return (static_cast<Phy*>(obj))->_sample_cb(data, nsamples, rx_time);       // NOLINT
 }
 
-const uint32_t kMaxBufferSamples = 2 * 15360;
+const uint32_t kMaxBufferSamples = 2 * 15360; // The buffer needs to be at least sf_samples * 40.
 const uint32_t kMaxSfn = 1024;
 const uint32_t kSfnOffset = 4;
 const uint32_t kSubframesPerFrame = 10;
@@ -44,10 +44,10 @@ const uint32_t kMaxValidFrames = 4;
 
 const uint32_t kMaxFramesTimeout = 80;
 
-Phy::Phy(const libconfig::Config& cfg, get_samples_t cb, uint8_t cs_nof_prb,
+Phy::Phy(get_samples_t cb, /*const libconfig::Config& cfg,*/ uint8_t cs_nof_prb,
          int8_t override_nof_prb, uint8_t rx_channels)
-    : _cfg(cfg),
-      _sample_cb(std::move(std::move(cb))),
+    : _sample_cb(std::move(std::move(cb))),
+//      _cfg(cfg),
       _cs_nof_prb(cs_nof_prb),
       _override_nof_prb(override_nof_prb),
       _rx_channels(rx_channels) {
@@ -57,8 +57,13 @@ Phy::Phy(const libconfig::Config& cfg, get_samples_t cb, uint8_t cs_nof_prb,
 }
 
 Phy::~Phy() {
+
   srsran_ue_sync_free(&_ue_sync);
-  free(_mib_buffer[0]);  // NOLINT
+  srsran_ue_mib_sync_free(&_mib_sync);
+  srsran_ue_mib_free(&_mib);
+  srsran_ue_cellsearch_free(&_cell_search);
+  free(_mib_buffer[0]);  // NOLINT 
+  free(_mib_buffer[1]);  // NOLINT 
 }
 
 auto Phy::synchronize_subframe() -> bool {
@@ -94,7 +99,7 @@ auto Phy::synchronize_subframe() -> bool {
 }
 
 auto Phy::cell_search() -> bool {
-  std::array<srsran_ue_cellsearch_result_t, kMaxCellsToDiscover> found_cells = {0};
+  std::array<srsran_ue_cellsearch_result_t, kMaxCellsToDiscover> found_cells = {{{0, SRSRAN_CP_EXT, SRSRAN_TDD, 0.0, 0.0, 0.0, 0.0}}}; // Default values to initialize the array.
 
   uint32_t max_peak_cell = 0;
   int ret = srsran_ue_cellsearch_scan(&_cell_search, found_cells.data(), &max_peak_cell);
@@ -133,7 +138,7 @@ auto Phy::cell_search() -> bool {
   ret = srsran_ue_mib_sync_decode_prb(&_mib_sync, kMaxFramesTimeout, bch_payload.data(), &new_cell.nof_ports, &sfn_offset, _cs_nof_prb);
 
   if (!ret) { // MIB-MBMS failed, try to decode regular MIB
-    init();
+  //  init();
     new_cell.mbms_dedicated = false;
     if (srsran_ue_mib_sync_set_cell_prb(&_mib_sync, new_cell, _cs_nof_prb) != 0) {
       spdlog::error("Phy: Error setting UE MIB sync cell");
@@ -218,6 +223,13 @@ auto Phy::init() -> bool {
     spdlog::error("Cannot init ue_mib");
     return false;
   }
+
+  // If we initialize this buffer the reception brokes
+/*  if (srsran_ue_mib_init(&_mib, _mib_buffer[1], MAX_PRB) != 0) {
+    spdlog::error("Cannot init ue_mib");
+    return false;
+  }*/
+
 
   return true;
 }
@@ -311,7 +323,7 @@ auto Phy::is_cas_subframe(unsigned tti) -> bool
     // This is subframe 0 in a radio frame divisible by 4, and hence a CAS frame. 
     return tti%40 == 0;
   } else {
-    unsigned sfn = tti / 10;
+    //unsigned sfn = tti / 10; //unused
     return (tti%10 == 0 || tti%10 == 5); 
   }
 }
@@ -365,7 +377,7 @@ auto Phy::mbsfn_config_for_tti(uint32_t tti, unsigned& area)
 
       for (uint32_t i = 0; i < _mcch.nof_pmch_info; i++) {
         unsigned fn_in_scheduling_period =  sfn % enum_to_number(_mcch.pmch_info_list[i].mch_sched_period);
-        unsigned sf_idx = fn_in_scheduling_period * 10 + sf 
+        uint16_t sf_idx = fn_in_scheduling_period * 10 + sf 
           - (fn_in_scheduling_period / 4) // minus 1 CAS SF per 4 SFNs 
           - 1; // minus 1 MCCH SF per scheduling period;
 
@@ -374,7 +386,7 @@ auto Phy::mbsfn_config_for_tti(uint32_t tti, unsigned& area)
         if (sf_idx <= _mcch.pmch_info_list[i].sf_alloc_end) {
           area = i;
           if ((i == 0 && fn_in_scheduling_period == 0 && sf == 1) ||
-              (i > 0 && _mcch.pmch_info_list[i-1].sf_alloc_end + 1 == sf_idx)) {
+              (i > 0 && _mcch.pmch_info_list[i-1].sf_alloc_end + 1U == sf_idx)) {
             spdlog::debug("assigning sig_mcs {}, mch_idx is {}",  area_info.mcch_cfg.sig_mcs, area);
             cfg.mbsfn_mcs = enum_to_number(area_info.mcch_cfg.sig_mcs);
           } else {

--- a/src/Phy.cpp
+++ b/src/Phy.cpp
@@ -76,7 +76,9 @@ auto Phy::synchronize_subframe() -> bool {
 
   if (ret == 1) {
     std::array<uint8_t, SRSRAN_BCH_PAYLOAD_LEN> bch_payload = {};
-    if (srsran_ue_sync_get_sfidx(&_ue_sync) == 0) {
+    auto sfn = srsran_ue_sync_get_sfn(&_ue_sync);
+    auto sf = srsran_ue_sync_get_sfidx(&_ue_sync);
+    if ((_cell.mbms_dedicated && sf == 0 && sfn % 4 == 0) || (!_cell.mbms_dedicated && sf == 0)) { 
       int sfn_offset = 0;
       int n =
           srsran_ue_mib_decode(&_mib, bch_payload.data(), nullptr, &sfn_offset);
@@ -137,8 +139,9 @@ auto Phy::cell_search() -> bool {
   srsran_ue_sync_reset(&_mib_sync.ue_sync);
   ret = srsran_ue_mib_sync_decode_prb(&_mib_sync, kMaxFramesTimeout, bch_payload.data(), &new_cell.nof_ports, &sfn_offset, _cs_nof_prb);
 
-  spdlog::info("Rel-16 PBCH repetition detected: {}", _mib_sync.ue_mib.pbch.cell.is_mbms_r16);
   new_cell.is_mbms_r16 = _mib_sync.ue_mib.pbch.cell.is_mbms_r16;
+  if (new_cell.is_mbms_r16) 
+    spdlog::info("Rel-16 cell detected");
 
   if (!ret) { // MIB-MBMS failed, try to decode regular MIB
   //  init();

--- a/src/Phy.h
+++ b/src/Phy.h
@@ -54,7 +54,7 @@ class Phy {
      *  @param cs_nof_prb  Nr of PRBs to use during cell search
      *  @param override_nof_prb  If set, overrides the nof PRB received in the MIB
      */
-    Phy(const libconfig::Config& cfg, get_samples_t cb, uint8_t cs_nof_prb, int8_t override_nof_prb, uint8_t rx_channels);
+    Phy(get_samples_t cb, /*const libconfig::Config& cfg,*/ uint8_t cs_nof_prb, int8_t override_nof_prb, uint8_t rx_channels);
     
     /**
      *  Default destructor.
@@ -290,7 +290,7 @@ class Phy {
     get_samples_t _sample_cb;
 
  private:
-    const libconfig::Config& _cfg;
+//    const libconfig::Config& _cfg; // unused
     srsran_ue_sync_t _ue_sync = {};
     srsran_ue_cellsearch_t _cell_search = {};
     srsran_ue_mib_sync_t  _mib_sync = {};

--- a/src/RestHandler.cpp
+++ b/src/RestHandler.cpp
@@ -36,7 +36,7 @@ using web::http::experimental::listener::http_listener_config;
 RestHandler::RestHandler(const libconfig::Config& cfg, const std::string& url,
                          state_t& state, SdrReader& sdr, Phy& phy,
                          set_params_t set_params)
-    : _cfg(cfg),
+    :/* _cfg(cfg),*/
       _state(state),
       _sdr(sdr),
       _phy(phy),

--- a/src/RestHandler.h
+++ b/src/RestHandler.h
@@ -70,8 +70,14 @@ class RestHandler {
     /**
      *  Start function for the listener.
      */
-    void start() { _listener->open().wait(); }
+    void start() { _listener->open().wait(); running = true; }
 
+    void stop() { 
+      if (running) {
+        _listener->close().wait();
+        running = false;
+      }
+    }
     /**
      *  RX Info pertaining to an SCH (MCCH/MCH or PDSCH)
      */
@@ -85,12 +91,20 @@ class RestHandler {
           std::lock_guard<std::mutex> lock(_data_mutex);
           return _data; 
         };
+        void add_error() { errors_total.fetch_add((uint64_t(1) << 32) | 1); } // error implica también +1 total
+        void add_total() { errors_total.fetch_add(1); }
+        std::pair<uint32_t, uint32_t> snapshot_and_reset() {
+          uint64_t snap = errors_total.exchange(0);
+          return { snap >> 32, snap & 0xFFFFFFFF };  // {errors, total}
+        }
         bool present = false;
         int mcs = 0;
         double ber;
         float evm_rms = 0.0f;
         unsigned total = 0;
         unsigned errors = 0;
+        std::atomic<uint64_t> errors_total {0};
+
       private:
         std::vector<uint8_t> _data = {};
         std::mutex _data_mutex;
@@ -170,10 +184,11 @@ class RestHandler {
     void get(web::http::http_request message);
     void put(web::http::http_request message);
 
-    const libconfig::Config& _cfg;
+//    const libconfig::Config& _cfg;
 
     std::unique_ptr<web::http::experimental::listener::http_listener> _listener;
 
+    bool running = false;
     state_t& _state;
     SdrReader& _sdr;
     Phy& _phy;

--- a/src/Rrc.cpp
+++ b/src/Rrc.cpp
@@ -77,7 +77,7 @@ void Rrc::write_pdu_bcch_dlsch(srsran::unique_byte_buffer_t pdu) {
 
     bcch_dl_sch_msg_s dlsch_msg1;
     asn1::cbit_ref    dlsch_bref(pdu->msg, pdu->N_bytes);
-    asn1::SRSASN_CODE err = dlsch_msg1.unpack(dlsch_bref);
+//    asn1::SRSASN_CODE err = dlsch_msg1.unpack(dlsch_bref);
 
     asn1::json_writer json_writer;
     dlsch_msg1.to_json(json_writer);
@@ -112,7 +112,7 @@ void Rrc::write_pdu_bcch_dlsch(srsran::unique_byte_buffer_t pdu) {
           //handle_sib13();
           break;
         default:
-          spdlog::debug("SIB{} is not supported\n", sib.type().to_number());
+          spdlog::debug("SIB{} is not supported\n", sib.type().to_string());
       }
     }
   }

--- a/src/Rrc.h
+++ b/src/Rrc.h
@@ -40,9 +40,9 @@ class Rrc : public srsue::rrc_interface_rlc, public srsue::rrc_interface_pdcp {
      *  @param rlc RLC reference
      *  @param rlc PHY reference
      */
-    Rrc(const libconfig::Config& cfg, Phy& phy, srsran::rlc& rlc)
-      : _cfg(cfg)
-      , _rlc(rlc)
+    Rrc(/*const libconfig::Config& cfg,*/ Phy& phy, srsran::rlc& rlc)
+      : /*_cfg(cfg)
+      ,*/ _rlc(rlc)
       , _phy(phy) {}
     virtual ~Rrc() = default;
 
@@ -68,19 +68,20 @@ class Rrc : public srsue::rrc_interface_rlc, public srsue::rrc_interface_pdcp {
     /**
      *  Handle SIB1(SIB13) from BCCH/DLSCH, and set the scheduling info in PHY.
      */
-    void write_pdu_bcch_dlsch(srsran::unique_byte_buffer_t pdu) override;
-    void write_pdu(uint32_t lcid, srsran::unique_byte_buffer_t pdu) override {}; // Unused
-    void write_pdu_bcch_bch(srsran::unique_byte_buffer_t pdu) override {}; // Unused
-    void write_pdu_pcch(srsran::unique_byte_buffer_t pdu) override {}; // Unused
-    const char* get_rb_name(uint32_t lcid) override { return "RB" + lcid; };
+    void write_pdu_bcch_dlsch([[maybe_unused]] srsran::unique_byte_buffer_t pdu) override;
+    void write_pdu([[maybe_unused]] uint32_t lcid, [[maybe_unused]] srsran::unique_byte_buffer_t pdu) override {}; // Unused
+    void write_pdu_bcch_bch([[maybe_unused]] srsran::unique_byte_buffer_t pdu) override {}; // Unused
+    void write_pdu_pcch([[maybe_unused]] srsran::unique_byte_buffer_t pdu) override {}; // Unused
+    const char* get_rb_name(uint32_t lcid) override { _rb_name = "RB" + std::to_string(lcid); return _rb_name.c_str(); };
     void protocol_failure() override {};
-    void notify_pdcp_integrity_error(uint32_t lcid) override {};
+    void notify_pdcp_integrity_error([[maybe_unused]] uint32_t lcid) override {};
 
  private:
     void handle_sib1(const asn1::rrc::sib_type1_mbms_r14_s& sib1);
     rrc_state_t _state = ACQUIRE_SIB;
 
-    const libconfig::Config& _cfg;
+ //   const libconfig::Config& _cfg;
     srsran::rlc& _rlc;
     Phy& _phy;
+    std::string _rb_name = "RB";
 };

--- a/src/SdrReader.cpp
+++ b/src/SdrReader.cpp
@@ -147,19 +147,16 @@ auto SdrReader::set_sample_rate(uint32_t rate, uint8_t idx) -> bool {
 auto SdrReader::set_gain(bool use_agc, double gain, uint8_t idx) -> bool {
   auto sdr = (SoapySDR::Device*)_sdr;
   if (sdr->hasGainMode(SOAPY_SDR_RX, idx)) {
-//    spdlog::info("{} AGC", use_agc ? "Enabling" : "Disabling");
+    spdlog::info("{} AGC", use_agc ? "Enabling" : "Disabling");
     sdr->setGainMode(SOAPY_SDR_RX, idx, use_agc);
   } else if (use_agc) {
-//    spdlog::info("AGC is not supported by this device, please set gain manually");
+    spdlog::info("AGC is not supported by this device, please set gain manually");
   }
   auto gain_range = sdr->getGainRange(SOAPY_SDR_RX, idx);
   _min_gain = gain_range.minimum();
   _max_gain = gain_range.maximum();
   if (gain >= gain_range.minimum() && gain <= gain_range.maximum()) {
     sdr->setGain( SOAPY_SDR_RX, idx, gain);
-    if (idx == 0) {
-      _gain = sdr->getGain( SOAPY_SDR_RX, idx);
-    }
     return true;
   } else {
     spdlog::error("Invalid gain setting {}. Allowed range is: {} - {}.", gain, gain_range.minimum(), gain_range.maximum());
@@ -198,11 +195,11 @@ auto SdrReader::tune(uint32_t frequency, uint32_t sample_rate,
   }
 
   _frequency = sdr->getFrequency( SOAPY_SDR_RX, 0);
-  bandwidth = sdr->getBandwidth( SOAPY_SDR_RX, 0);
+  _filterBw = static_cast<unsigned>(sdr->getBandwidth( SOAPY_SDR_RX, 0));
   _sampleRate = sdr->getSampleRate( SOAPY_SDR_RX, 0);
 
   spdlog::info("SDR tuned to {} MHz, filter bandwidth {} MHz, sample rate {}, gain {}, antenna path {}",
-      _frequency/1000000.0, bandwidth/1000000.0, _sampleRate/1000000.0, _gain, _antenna);
+      _frequency/1000000.0, _filterBw/1000000.0, _sampleRate/1000000.0, _gain, _antenna);
 
 
   auto sensors = sdr->listSensors();
@@ -215,6 +212,7 @@ auto SdrReader::tune(uint32_t frequency, uint32_t sample_rate,
 }
 
 void SdrReader::start() {
+  spdlog::debug("Starting SdrReader");
   if (_sdr != nullptr) {
     auto sdr = (SoapySDR::Device*)_sdr;
     std::vector<size_t> channels(_rx_channels);
@@ -255,6 +253,7 @@ void SdrReader::start() {
 
 void SdrReader::stop() {
   _running = false;
+  spdlog::debug("Stoping SdrReader");
 
   _readerThread.join();
   if (_sdr != nullptr) {
@@ -277,9 +276,7 @@ void SdrReader::read() {
     //int toRead = 254;
     if (_buffer->free_size() < toRead * sizeof(cf_t)) {
       spdlog::debug("ringbuffer overflow");
-  //    std::this_thread::sleep_for(std::chrono::microseconds(1000));
-      next_tick += tick_step;//std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * toRead));
-    //  std::this_thread::sleep_until(next_tick);
+      next_tick += tick_step;
     } else {
       unsigned int read = 0;
       size_t writeable = 0;
@@ -290,8 +287,6 @@ void SdrReader::read() {
       int writeable_write_samples = (int)floor(writeable_write / sizeof(cf_t));
 
       if (_reading_from_file) {
-  //      std::chrono::steady_clock::time_point entered = {};
-  //      entered = std::chrono::steady_clock::now();
 
         read = srsran_filesource_read_multi(&file_source, buffers.data(), std::min(writeable_samples, toRead), (int)_rx_channels);
         if ( read == 0  ) {
@@ -299,25 +294,16 @@ void SdrReader::read() {
             srsran_filesource_seek(&file_source, 0);
           } else {
             spdlog::info("EOF, exiting...");
-            //raise(SIGINT); //SIGINT to signal srsran that we want to exit.
-            _running = false; //stop();
+            _running = false;
           }
         }
         read = read / _rx_channels;
-       // int64_t required_time_us = (1000000.0/_sampleRate) * read;
 
         if (read > 0) {
           _buffer->commit( read * sizeof(cf_t) );
         }
-
-     //   std::chrono::microseconds sleep = (std::chrono::microseconds(required_time_us) -
-     //       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - entered));
      
-  //  tick_step = std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * read));
        next_tick += std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * read)); 
-        //spdlog::info("We spend {} microseconds reading from file",std::chrono::duration_cast<std::chrono::microseconds>(sleep).count());
-      //  std::this_thread::sleep_for(sleep);
-      //  std::this_thread::sleep_until(next_tick);
       } else {
         auto sdr = (SoapySDR::Device*)_sdr;
         int flags = 0;
@@ -331,10 +317,10 @@ void SdrReader::read() {
           if (_writing_to_file && _write_samples && writeable_write_samples) { // Only if we are going to write into a file.
             auto wbuff = buffers_write.data();
             for (size_t  i = 0; i < _rx_channels; i++) {
-      //        spdlog::info("muestras leídas (read) {}, buffer usado para escribir {}, capacidad {}, buffer de lectura usado {}, capacidad de lectura {}", read, _buffer_write->used_size(), _buffer_write->capacity(), _buffer->used_size(), _buffer->capacity()); 
+              spdlog::debug("Read samples (read) {}, buffer for writting {}, capacity {}, used buffer {}, read capacity {}", read, _buffer_write->used_size(), _buffer_write->capacity(), _buffer->used_size(), _buffer->capacity()); 
              memcpy(wbuff[i], rbuff[i], std::min(writeable_write_samples, toRead) * sizeof(cf_t)); // Copy the data in the input buffer to the toWrite buffer.
             }
-            _buffer_write->commit( std::min(writeable_write_samples, toRead) * sizeof(cf_t)); // We used another ring buffer for the written of the samples, to not block a lot we only write to the disk when the ring buffer is at 95% of its capacity
+            _buffer_write->commit( std::min(writeable_write_samples, toRead) * sizeof(cf_t)); // We used another ring buffer for the writting of the samples, to not block a lot we only write to the disk when the ring buffer is at 95% of its capacity
           }
           _buffer->commit( read * sizeof(cf_t) );
     

--- a/src/SdrReader.cpp
+++ b/src/SdrReader.cpp
@@ -324,7 +324,7 @@ void SdrReader::read() {
           }
           _buffer->commit( read * sizeof(cf_t) );
     
-          if (_writing_to_file && _write_samples && _buffer_write->used_size() >= 0.95* _buffer_write->capacity()) {
+          if (_writing_to_file && _write_samples && static_cast<double>(_buffer_write->used_size()) >= 0.95* static_cast<double>(_buffer_write->capacity())) {
             unsigned int toWrite_samples = _buffer_write->used_size() / sizeof(cf_t); // We are going to storage all the info
             auto buff_to_write = _buffer_write->read_head(); // Gives the beggining of the buffer, it also puts _used and _head to 0, to start adding at the beggining again.
             srsran_filesink_write_multi(&file_sink, buff_to_write.data(), static_cast<int>(toWrite_samples), static_cast<int>(_rx_channels)); // From the begginin of the buffer we write used_size data
@@ -355,16 +355,16 @@ auto SdrReader::get_samples(cf_t* data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, 
   std::chrono::steady_clock::time_point entered = {};
   entered = std::chrono::steady_clock::now();
 
-  int64_t required_time_us = (1000000.0/_sampleRate) * nsamples;
+  int64_t required_time_us = static_cast<int64_t>((1000000.0/_sampleRate)) * nsamples;
   double half_buffer_size = (_sampleRate / 1000.0f) * (static_cast<double>(_buffer_ms) * 0.50f) * sizeof(cf_t);
   size_t cnt = nsamples * sizeof(cf_t);
 
-  if (_high_watermark_reached &&  _buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms * 0.2) * sizeof(cf_t)) {
+  if (_high_watermark_reached &&  static_cast<double>(_buffer->used_size()) < (_sampleRate / 1000.0) * (_buffer_ms * 0.2) * sizeof(cf_t)) {
     _high_watermark_reached = false;
   }
 
   if (!_high_watermark_reached) {
-    while (_buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms * 0.2) * sizeof(cf_t)) {
+    while (static_cast<double>(_buffer->used_size()) < (_sampleRate / 1000.0) * (_buffer_ms * 0.2) * sizeof(cf_t)) {
       std::this_thread::sleep_for(std::chrono::microseconds(5));
     }
     spdlog::debug("Filled ringbuffer to half capacity");
@@ -402,7 +402,7 @@ auto SdrReader::get_samples(cf_t* data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, 
   }
   */
 
-  required_time_us += static_cast<int>(((half_buffer_size - _buffer->used_size()) / half_buffer_size) * 500.0); // We adjust the required time respect to the middle of the buffer, the objetive is to have the buffer always at the half.
+  required_time_us += static_cast<int>(((half_buffer_size - static_cast<double>(_buffer->used_size())) / half_buffer_size) * 500.0); // We adjust the required time respect to the middle of the buffer, the objetive is to have the buffer always at the half.
 
   spdlog::debug("took {}, read {} samples, samplerate is {}, adjusted required {} us, delta {} us, sleep adj {},  sleeping for {} us",
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - entered).count(),
@@ -419,7 +419,7 @@ auto SdrReader::get_samples(cf_t* data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, 
     std::this_thread::sleep_for(sleep);
     _sleep_adjustment = 0;
   } else if (sleep.count() > -100000) {
-    _sleep_adjustment = sleep.count();
+    _sleep_adjustment = static_cast<int>(sleep.count());
   }
 
   _last_read = std::chrono::steady_clock::now();

--- a/src/SdrReader.cpp
+++ b/src/SdrReader.cpp
@@ -51,9 +51,9 @@ void SdrReader::enumerateDevices()
   auto results = SoapySDR::Device::enumerate();
 	SoapySDR::Kwargs::iterator it;
 
-	for( int i = 0; i < results.size(); ++i)
+	for( size_t i = 0; i < results.size(); ++i)
 	{
-		printf("Device #%d:\n", i);
+		printf("Device #%zu:\n", i);
 		for( it = results[i].begin(); it != results[i].end(); ++it)
 		{
 			printf("%s = %s\n", it->first.c_str(), it->second.c_str());
@@ -101,6 +101,7 @@ auto SdrReader::init(const std::string& device_args, const char* sample_file,
 
 void SdrReader::init_buffer() {
   auto buffer_size = (unsigned int)ceil(_sampleRate/1000.0 * _buffer_ms);
+  spdlog::info("SoapySDR: initiating _buffer (RingBuffer) of size {}", buffer_size);
   _buffer = std::make_unique<MultichannelRingbuffer>(sizeof(cf_t) * buffer_size, _rx_channels);
   _buffer_write = std::make_unique<MultichannelRingbuffer>(sizeof(cf_t) * buffer_size / 2, _rx_channels); // This is the buffer where we will store the samples to write a big chunk of samples instead many little ones. 1 GB seems to be a sweet amount to write (16e6 * sizeof(cf_t) = 1GB).
   _buffer_ready = true;
@@ -188,7 +189,7 @@ auto SdrReader::tune(uint32_t frequency, uint32_t sample_rate,
 
   auto sdr = (SoapySDR::Device*)_sdr;
 
-  for (auto ch = 0; ch < _rx_channels; ch++) {
+  for (size_t ch = 0; ch < _rx_channels; ch++) {
     set_antenna(antenna, ch);
     set_gain(_use_agc, gain, ch);
     set_frequency(frequency, ch);
@@ -217,7 +218,7 @@ void SdrReader::start() {
   if (_sdr != nullptr) {
     auto sdr = (SoapySDR::Device*)_sdr;
     std::vector<size_t> channels(_rx_channels);
-    for (auto ch = 0; ch < _rx_channels; ch++) {
+    for (size_t ch = 0; ch < _rx_channels; ch++) {
       channels[ch] = ch;
     }
     sdr->setHardwareTime(0); // Set SDR timestamp to zero.
@@ -266,15 +267,21 @@ void SdrReader::stop() {
 }
 
 void SdrReader::read() {
-  std::array<void*, SRSRAN_MAX_CHANNELS> radio_buffers = { nullptr };
+  //std::array<void*, SRSRAN_MAX_CHANNELS> radio_buffers = { nullptr }; // unused
+
+  auto next_tick = std::chrono::steady_clock::now();
   while (_running) {
     int toRead = ceil(_sampleRate / 1000.0);
+
+    auto tick_step = std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * toRead));
     //int toRead = 254;
     if (_buffer->free_size() < toRead * sizeof(cf_t)) {
       spdlog::debug("ringbuffer overflow");
-      std::this_thread::sleep_for(std::chrono::microseconds(1000));
+  //    std::this_thread::sleep_for(std::chrono::microseconds(1000));
+      next_tick += tick_step;//std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * toRead));
+    //  std::this_thread::sleep_until(next_tick);
     } else {
-      int read = 0;
+      unsigned int read = 0;
       size_t writeable = 0;
       size_t writeable_write = 0;
       auto buffers = _buffer->write_head(&writeable);
@@ -283,8 +290,8 @@ void SdrReader::read() {
       int writeable_write_samples = (int)floor(writeable_write / sizeof(cf_t));
 
       if (_reading_from_file) {
-        std::chrono::steady_clock::time_point entered = {};
-        entered = std::chrono::steady_clock::now();
+  //      std::chrono::steady_clock::time_point entered = {};
+  //      entered = std::chrono::steady_clock::now();
 
         read = srsran_filesource_read_multi(&file_source, buffers.data(), std::min(writeable_samples, toRead), (int)_rx_channels);
         if ( read == 0  ) {
@@ -292,42 +299,49 @@ void SdrReader::read() {
             srsran_filesource_seek(&file_source, 0);
           } else {
             spdlog::info("EOF, exiting...");
-            raise(SIGINT); //SIGINT to signal srsran that we want to exit.
+            //raise(SIGINT); //SIGINT to signal srsran that we want to exit.
+            _running = false; //stop();
           }
         }
         read = read / _rx_channels;
-        int64_t required_time_us = (1000000.0/_sampleRate) * read;
+       // int64_t required_time_us = (1000000.0/_sampleRate) * read;
 
         if (read > 0) {
           _buffer->commit( read * sizeof(cf_t) );
         }
 
-        std::chrono::microseconds sleep = (std::chrono::microseconds(required_time_us) -
-            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - entered));
-        std::this_thread::sleep_for(sleep);
+     //   std::chrono::microseconds sleep = (std::chrono::microseconds(required_time_us) -
+     //       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - entered));
+     
+  //  tick_step = std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * read));
+       next_tick += std::chrono::microseconds((int64_t)(1000000.0 / _sampleRate * read)); 
+        //spdlog::info("We spend {} microseconds reading from file",std::chrono::duration_cast<std::chrono::microseconds>(sleep).count());
+      //  std::this_thread::sleep_for(sleep);
+      //  std::this_thread::sleep_until(next_tick);
       } else {
         auto sdr = (SoapySDR::Device*)_sdr;
         int flags = 0;
         long long time_ns = 0;
-        auto rbuff = buffers.data();
-        auto wbuff = buffers_write.data();
  
         read = sdr->readStream( (SoapySDR::Stream*)_stream, buffers.data(), std::min(writeable_samples, toRead), flags, time_ns);
 
         if (read> 0 ) {
-         
+          auto rbuff = buffers.data();
+          
           if (_writing_to_file && _write_samples && writeable_write_samples) { // Only if we are going to write into a file.
-            for (int i = 0; i < _rx_channels; i++) {
-             memcpy(wbuff[i], rbuff[i], std::min(writeable_write_samples, read) * sizeof(cf_t)); // Copy the data in the input buffer to the toWrite buffer.
+            auto wbuff = buffers_write.data();
+            for (size_t  i = 0; i < _rx_channels; i++) {
+      //        spdlog::info("muestras leídas (read) {}, buffer usado para escribir {}, capacidad {}, buffer de lectura usado {}, capacidad de lectura {}", read, _buffer_write->used_size(), _buffer_write->capacity(), _buffer->used_size(), _buffer->capacity()); 
+             memcpy(wbuff[i], rbuff[i], std::min(writeable_write_samples, toRead) * sizeof(cf_t)); // Copy the data in the input buffer to the toWrite buffer.
             }
-            _buffer_write->commit( std::min(writeable_write_samples, read) * sizeof(cf_t)); // We used another ring buffer for the written of the samples, to not block a lot we only write to the disk when the ring buffer is at 90% of its capacity
+            _buffer_write->commit( std::min(writeable_write_samples, toRead) * sizeof(cf_t)); // We used another ring buffer for the written of the samples, to not block a lot we only write to the disk when the ring buffer is at 95% of its capacity
           }
           _buffer->commit( read * sizeof(cf_t) );
     
-          if (_writing_to_file && _write_samples && _buffer_write->used_size() >= 0.90* _buffer_write->capacity()) {
-            int toWrite_samples = _buffer_write->used_size() / sizeof(cf_t); // We are going to storage all the info
+          if (_writing_to_file && _write_samples && _buffer_write->used_size() >= 0.95* _buffer_write->capacity()) {
+            unsigned int toWrite_samples = _buffer_write->used_size() / sizeof(cf_t); // We are going to storage all the info
             auto buff_to_write = _buffer_write->read_head(); // Gives the beggining of the buffer, it also puts _used and _head to 0, to start adding at the beggining again.
-            srsran_filesink_write_multi(&file_sink, buff_to_write.data(), toWrite_samples, (int)_rx_channels); // From the beggining of the buffer we write used_size data
+            srsran_filesink_write_multi(&file_sink, buff_to_write.data(), static_cast<int>(toWrite_samples), static_cast<int>(_rx_channels)); // From the begginin of the buffer we write used_size data
           }
               spdlog::debug("buffer: commited {}, requested {}, writeable {}, writeable_write {}, flags {}", read, toRead, writeable_samples, writeable_write_samples, flags);
         }
@@ -338,6 +352,13 @@ void SdrReader::read() {
         }
       }
     }
+    auto now = std::chrono::steady_clock::now();
+    if (next_tick < now) {
+        //  auto overrun_us = std::chrono::duration_cast<std::chrono::microseconds>(now - next_tick).count();
+        //  auto remainder_us = tick_step.count() - (overrun_us);
+        next_tick = now;
+    }
+    std::this_thread::sleep_until(next_tick);
   }
   spdlog::debug("Sample reader thread exited");
 }
@@ -349,35 +370,58 @@ auto SdrReader::get_samples(cf_t* data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, 
   entered = std::chrono::steady_clock::now();
 
   int64_t required_time_us = (1000000.0/_sampleRate) * nsamples;
+  double half_buffer_size = (_sampleRate / 1000.0f) * (static_cast<double>(_buffer_ms) * 0.50f) * sizeof(cf_t);
   size_t cnt = nsamples * sizeof(cf_t);
 
-  if (_high_watermark_reached &&  _buffer->used_size() < (_sampleRate / 1000.0) * 10 * sizeof(cf_t)) {
+  if (_high_watermark_reached &&  _buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms * 0.2) * sizeof(cf_t)) {
     _high_watermark_reached = false;
   }
 
   if (!_high_watermark_reached) {
-    while (_buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms / 2.0) * sizeof(cf_t)) {
-      std::this_thread::sleep_for(std::chrono::microseconds(500));
+    while (_buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms * 0.2) * sizeof(cf_t)) {
+      std::this_thread::sleep_for(std::chrono::microseconds(5));
     }
     spdlog::debug("Filled ringbuffer to half capacity");
     _high_watermark_reached = true;
   }
 
+//  spdlog::info("_buffer->used_size() {}", _buffer->used_size());
+/*    while (_buffer->used_size() < cnt) {
+          std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+    
+    */
+
+//  if (_buffer->used_size() < cnt*4) {
+//    spdlog::info(" WARNING: We are consuming the buffer TOO fast (4 hilos)");
+//  }
   std::vector<char*> buffers(_rx_channels);
-  for (auto ch = 0; ch < _rx_channels; ch++) {
+  for (size_t ch = 0; ch < _rx_channels; ch++) {
     buffers[ch] = (char*)data[ch];
   }
   _buffer->read(buffers, cnt); // Copy from the ringbuffer to the data array. This also decreases _used.
 
-  if (_buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms / 4.0) * sizeof(cf_t)) {
-    required_time_us += 500;
-  } else {
-    required_time_us -= 500;
-  }
+//    if (_reading_from_file) {
+//      return 0;
+//    }
 
-  spdlog::debug("took {}, read {} samples, adjusted required {} us, delta {} us, sleep adj {},  sleeping for {} us",
+
+/*
+  if (_buffer->used_size() < (_sampleRate / 1000.0) * (_buffer_ms * 0.45) * sizeof(cf_t)) {
+    required_time_us += 40;
+    //spdlog::info(" WARNING: We are consuming the buffer TOO fast ");
+  } else if (_buffer->used_size() > (_sampleRate / 1000.0) * (_buffer_ms * 0.55) * sizeof(cf_t)) {
+    //spdlog::info(" We are SLOOW ");
+    required_time_us -= 40;
+  }
+  */
+
+  required_time_us += static_cast<int>(((half_buffer_size - _buffer->used_size()) / half_buffer_size) * 500.0); // We adjust the required time respect to the middle of the buffer, the objetive is to have the buffer always at the half.
+
+  spdlog::debug("took {}, read {} samples, samplerate is {}, adjusted required {} us, delta {} us, sleep adj {},  sleeping for {} us",
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - entered).count(),
       nsamples,
+      _sampleRate,
       std::chrono::microseconds(required_time_us).count(),
       std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - _last_read).count(),
       _sleep_adjustment,
@@ -393,6 +437,7 @@ auto SdrReader::get_samples(cf_t* data[SRSRAN_MAX_CHANNELS], uint32_t nsamples, 
   }
 
   _last_read = std::chrono::steady_clock::now();
+  //  }*/
   return 0;
 }
 

--- a/src/SdrReader.h
+++ b/src/SdrReader.h
@@ -62,8 +62,7 @@ public:
     /**
      * Tune the SDR to the desired frequency, and set gain, filter and antenna parameters.
      */
-    bool tune(uint32_t frequency, uint32_t sample_rate, uint32_t bandwidth, double gain, const std::string &antenna,
-              bool use_agc);
+    bool tune(uint32_t frequency, uint32_t sample_rate, uint32_t bandwidth, double gain, const std::string &antenna, bool use_agc);
 
     /**
      * Start reading samples from the SDR

--- a/src/SdrReader.h
+++ b/src/SdrReader.h
@@ -42,7 +42,7 @@ public:
      *  @param cfg Config singleton reference
      */
     explicit SdrReader(const libconfig::Config &cfg, size_t rx_channels)
-            : _overflows(0), _underflows(0), _cfg(cfg), _rx_channels(rx_channels), _readerThread{} {}
+            : _cfg(cfg), _readerThread{}, _rx_channels(rx_channels)/*, _overflows(0), _underflows(0)*/  {}
 
     /**
      *  Default destructor.
@@ -138,6 +138,7 @@ public:
      */
     void disableSampleFileWriting() { _write_samples = false; }
 
+    bool is_running(){ return _running; }
 private:
     void init_buffer();
 
@@ -173,10 +174,10 @@ private:
     double _min_gain;
     double _max_gain;
     std::string _antenna;
-    unsigned _overflows;
-    unsigned _underflows;
+//    unsigned _overflows; //unused
+//    unsigned _underflows; //unused
 
-    cf_t *_read_buffer;
+//    cf_t *_read_buffer; //unused
 
     srsran_filesource_t file_source;
     srsran_filesink_t file_sink;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,6 +192,15 @@ static unsigned cas_nof_prb = 0;
  */
 static bool restart = false;
 
+
+static std::atomic<bool> running(true);
+
+void signalHandler([[maybe_unused]] int signum) {
+  running = false; // We finish cleanly 
+}
+
+
+
 /**
  * Set new SDR parameters and initialize resynchronisation. This function is used by the RESTful API handler
  * to modify the SDR params.
@@ -222,6 +231,8 @@ void set_params(const std::string& ant, unsigned fc, double g, unsigned sr, unsi
  * @return 0 on clean exit, -1 on failure
  */
 auto main(int argc, char **argv) -> int {
+  try {
+  signal(SIGINT, signalHandler);
   struct arguments arguments;
   /* Default values */
   arguments.config_file = "/etc/5gmag-rt.conf";
@@ -305,7 +316,7 @@ auto main(int argc, char **argv) -> int {
   cfg.lookupValue("modem.phy.threads", thread_cnt);
   int phy_prio = 10;
   cfg.lookupValue("modem.phy.thread_priority_rt", phy_prio);
-  thread_pool pool{ thread_cnt + 1, phy_prio };
+  thread_pool pool{ thread_cnt /*+ 1*/, phy_prio };
 
   // Elevate execution to real time scheduling
   struct sched_param thread_param = {};
@@ -325,20 +336,20 @@ auto main(int argc, char **argv) -> int {
 
   // Create the layer components: Phy, RLC, RRC and GW
   Phy phy(
-      cfg,
       std::bind(&SdrReader::get_samples, &sdr, _1, _2, _3),  // NOLINT
+ //     cfg,
       arguments.file_bw ? arguments.file_bw * 5 : 25,
       arguments.override_nof_prb,
       rx_channels);
 
   phy.init();
 
+  srsran::timer_handler timers; // timer must be declared before RLC to avoid a heap-use-after-free when existing
   srsran::pdcp pdcp(nullptr, "PDCP");
   srsran::rlc rlc("RLC");
-  srsran::timer_handler timers;
 
-  Rrc rrc(cfg, phy, rlc);
-  Gw gw(cfg, phy);
+  Rrc rrc(/*cfg,*/ phy, rlc);
+  Gw gw(/*cfg,*/ phy);
   gw.init();
 
   rlc.init(&pdcp, &rrc, &timers, 0 /* RB_ID_SRB0 */);
@@ -353,6 +364,19 @@ auto main(int argc, char **argv) -> int {
     case 4: srs_level = srslog::basic_levels::none; break;
   }
 
+
+  // Configurar sink de srslog — redirigir a stdout
+ /* auto* log_sink = srslog::create_stdout_sink();
+  if (!log_sink) {
+  spdlog::error("Failed to create srslog stdout sink");
+  exit(1);
+  }
+  srslog::log_channel* chan = srslog::create_log_channel("main_channel", *log_sink);
+  srslog::set_default_sink(*log_sink);
+  
+ // Arrancar el backend de srslog — SIN esto ningún log aparece
+  srslog::init();
+  */
   // Configure srsLTE logging
  auto& mac_log = srslog::fetch_basic_logger("MAC", false);
   mac_log.set_level(srs_level);
@@ -373,7 +397,7 @@ auto main(int argc, char **argv) -> int {
   RestHandler rest_handler(cfg, uri, state, sdr, phy, set_params);
 
   // Initialize one CAS and thered_cnt MBSFN frame processors
-  CasFrameProcessor cas_processor(cfg, phy, rlc, rest_handler, rx_channels);
+  CasFrameProcessor cas_processor(/*cfg,*/ phy, rlc, rest_handler, rx_channels);
   if (!cas_processor.init()) {
     spdlog::error("Failed to create CAS processor. Exiting.");
     exit(1);
@@ -383,15 +407,21 @@ auto main(int argc, char **argv) -> int {
   rest_handler.set_cas_processor(&cas_processor);
   
   std::vector<MbsfnFrameProcessor*> mbsfn_processors;
-  for (int i = 0; i < thread_cnt; i++) {
+  ProcessorQueue free_processors;
+  for (size_t i = 0; i < thread_cnt; i++) {
     auto p = new MbsfnFrameProcessor(cfg, rlc, phy, mac_log, rest_handler, rx_channels);
     if (!p->init()) {
       spdlog::error("Failed to create MBSFN processor. Exiting.");
       exit(1);
     }
     mbsfn_processors.push_back(p);
+    free_processors.push(p);
   }
 
+
+//  for (auto& p : mbsfn_processors)
+//  {
+//  }
   rest_handler.start(); // Start the listener, we need to do it after storing the cas into the rest_handler, otherwise we will get segfault.
   // Start receiving sample data
   sdr.start();
@@ -407,7 +437,7 @@ auto main(int argc, char **argv) -> int {
   // Variables to store the times the receiver losses the signal and the lost subframes between resynchronizations.
   uint32_t sync_losses = 0;
   uint32_t lost_subframes = 0;
-  uint32_t measurements = 0.0f;
+//  uint32_t measurements = 0;
 
   uint32_t tti = 0;
 
@@ -419,12 +449,15 @@ auto main(int argc, char **argv) -> int {
   // Initial state: searching a cell
   state = searching;
 
+  sdr.enableSampleFileWriting();
+  
   uint8_t mb_idx = 0;
   // Start the main processing loop
-  for (;;) { // Only one main loop, any time therè's a change of state we force next iteration with continue. This way there's no need of nested loops within the cases.
+  while (running && sdr.is_running()) { // Only one main loop, any time therè's a change of state we force next iteration with continue. This way there's no need of nested loops within the cases.
     switch (state) {
       case processing: {  // processing
         tti = (tti + 1) % 10240; // Clamp the TTI
+        //unsigned sfn = tti / 10; // unused
         if (phy.is_cas_subframe(tti)) {
           // Get the samples from the SDR interface, hand them to a CAS processor, and start it
           // on a thread from the pool.
@@ -461,13 +494,16 @@ auto main(int argc, char **argv) -> int {
 
               sdr.start();
               spdlog::info("Synchronizing subframe after PRB extension");
+              //MbsfnFrameProcessor::stop_delivery_worker();
               state = syncing;
             }
           } else {
             // Failed to receive data, or sync lost. Go back to searching state.
             spdlog::warn("Synchronization lost while processing. Going back to searching state.");
             sync_losses++;
+//            MbsfnFrameProcessor::stop_delivery_worker();
             state = syncing;
+//            auto t2 = std::chrono::high_resolution_clock::now();
           }
         } else {
           // All other frames in FeMBMS dedicated mode are MBSFN frames.
@@ -475,36 +511,71 @@ auto main(int argc, char **argv) -> int {
 
           // Get the samples from the SDR interface, hand them to an MNSFN processor, and start it
           // on a thread from the pool. Getting the buffer pointer from the pool also locks this processor.
-          if (!restart && phy.get_next_frame(mbsfn_processors[mb_idx]->get_rx_buffer_and_lock(), mbsfn_processors[mb_idx]->rx_buffer_size())) {
-            if (phy.mcch_configured() && phy.is_mbsfn_subframe(tti)) {
-              // If data frm SIB1/SIB13 has been received in CAS, configure the processors accordingly
-              if (!mbsfn_processors[mb_idx]->mbsfn_configured()) {
-                srsran_scs_t scs = SRSRAN_SCS_15KHZ;
-                switch (phy.mbsfn_subcarrier_spacing()) {
-                  case Phy::SubcarrierSpacing::df_15kHz:  scs = SRSRAN_SCS_15KHZ; break;
-                  case Phy::SubcarrierSpacing::df_7kHz5:  scs = SRSRAN_SCS_7KHZ5; break;
-                  case Phy::SubcarrierSpacing::df_1kHz25: scs = SRSRAN_SCS_1KHZ25; break;
+          auto t1 = std::chrono::high_resolution_clock::now();
+          auto t2 = t1;
+
+        //  while (true) // Let's see which mbsfn processor is available
+        //  {
+        //    mb_idx = static_cast<int>((++mb_idx) % thread_cnt);
+          //  spdlog::debug("Probing mbs_processor {}.", mb_idx);
+            auto* proc = free_processors.pop();//mbsfn_processors[mb_idx]; // Grab a processor
+
+//            if (/*auto buf = proc->try_get_rx_buffer_and_lock()*/ !proc->busy.exchange(true, std::memory_order_acquire)) { // Try to catch mbsfn processor i
+          //  spdlog::info("Grab processor {}.", proc->get_id());
+              // If its available we can launch it
+              if (!restart && phy.get_next_frame(proc->get_rx_buffer(), proc->rx_buffer_size())) {
+                t2 = std::chrono::high_resolution_clock::now();
+                if (phy.mcch_configured() && phy.is_mbsfn_subframe(tti)) {
+                  // If data frm SIB1/SIB13 has been received in CAS, configure the processors accordingly
+                  if (!/*mbsfn_processors[mb_idx]*/proc->mbsfn_configured()) {
+                    srsran_scs_t scs = SRSRAN_SCS_15KHZ;
+                    switch (phy.mbsfn_subcarrier_spacing()) {
+                      case Phy::SubcarrierSpacing::df_15kHz:  scs = SRSRAN_SCS_15KHZ; break;
+                      case Phy::SubcarrierSpacing::df_7kHz5:  scs = SRSRAN_SCS_7KHZ5; break;
+                      case Phy::SubcarrierSpacing::df_1kHz25: scs = SRSRAN_SCS_1KHZ25; break;
+                    }
+                    auto cell = phy.cell();
+                    cell.nof_prb = cell.mbsfn_prb;
+                    /*mbsfn_processors[mb_idx]->set_cell(cell);
+                    mbsfn_processors[mb_idx]->configure_mbsfn(phy.mbsfn_area_id(), scs);
+                    */
+                    proc->set_cell(cell);
+                    proc->configure_mbsfn(phy.mbsfn_area_id(), scs);
+
+                  }
+          //  spdlog::info("Before push.");
+                  pool.push([ObjectPtr = proc /*mbsfn_processors[mb_idx]*/, tti, &free_processors] {
+          //  spdlog::info("Lnching process {}.", ObjectPtr->get_id());
+                    ObjectPtr->process(tti);
+                    //proc->process(tti);
+         //   spdlog::info("Queueing processor {}.", ObjectPtr->get_id());
+                    free_processors.push(ObjectPtr);
+                    //ObjectPtr->unlock();
+                  });
+                } else {
+                  // Nothing to do yet, we lack the data from SIB1/SIB13
+                  // Discard the samples and unlock the processor.
+                //  mbsfn_processors[mb_idx]->unlock();
+                  //proc->unlock();
+                  //proc->release();
+                  free_processors.push(proc); // Back to the queue
                 }
-                auto cell = phy.cell();
-                cell.nof_prb = cell.mbsfn_prb;
-                mbsfn_processors[mb_idx]->set_cell(cell);
-                mbsfn_processors[mb_idx]->configure_mbsfn(phy.mbsfn_area_id(), scs);
+              } else {
+                // Failed to receive data, or sync lost. Go back to searching state.
+                spdlog::warn("Synchronization lost while processing. Going back to searching state, we were waiting {} microseconds.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
+                sync_losses++; 
+//                MbsfnFrameProcessor::stop_delivery_worker();
+                state = syncing;
+                free_processors.push(proc); // Back to the queue
               }
-              pool.push([ObjectPtr = mbsfn_processors[mb_idx], tti] {
-                ObjectPtr->process(tti);
-              });
-            } else {
-              // Nothing to do yet, we lack the data from SIB1/SIB13
-              // Discard the samples and unlock the processor.
-              mbsfn_processors[mb_idx]->unlock();
-            }
-          } else {
-            // Failed to receive data, or sync lost. Go back to searching state.
-            spdlog::warn("Synchronization lost while processing. Going back to searching state.");
-            sync_losses++; 
-            state = syncing;
-          }
-          mb_idx = static_cast<int>((mb_idx + 1) % thread_cnt);
+              //mb_idx = static_cast<int>((mb_idx + 1) % thread_cnt);
+            //  break; // Stops searching in this iteration for an available processor
+ //           }
+            
+         // }
+        //  if (std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() > 2000)
+           // spdlog::info("We waited {} microseconds for mbs_processor {}.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count(), proc->get_id());
+//          mb_idx = static_cast<int>((mb_idx + 1) % thread_cnt);
         }
       }
       break;
@@ -518,7 +589,7 @@ auto main(int argc, char **argv) -> int {
         }
 
         // We're at the search sample rate, and there's no point in creating a sample file. rtop the sample writer, if enabled.
-        //sdr.disableSampleFileWriting();
+   //     sdr.disableSampleFileWriting();
 
         // In searching state, clear the receive buffer and try to find a cell at the configured frequency and synchronize with it
         restart = false;
@@ -577,16 +648,17 @@ auto main(int argc, char **argv) -> int {
           // Set the cell parameters in the CAS processor, and set started to true
           cas_processor.set_cell(phy.cell());
 
-          for (int i = 0; i < thread_cnt; i++) {
-            mbsfn_processors[i]->unlock();
-          }
+//          for (int i = 0; i < thread_cnt; i++) {
+            //mbsfn_processors[i]->unlock();
+//            mbsfn_processors[i]->release();
+//          }
           cas_processor.unlock(); // We need to unlock because we felt here from processing after calling get_rx_buffer_and_lock()
 
           // Get the initial TTI / subframe ID (= system frame number * 10 + subframe number)
           tti = phy.tti();
           // Reset the RRC
           rrc.reset();
-
+//          MbsfnFrameProcessor::start_delivery_worker(rlc, phy/*, timers*/);
           // Ready to receive actual data. Go to processing state.
           state = processing;
 
@@ -601,7 +673,19 @@ auto main(int argc, char **argv) -> int {
     }
     
     tick++;
-    if (tick%measurement_interval == 0) {
+    timers.step_all();
+   /* {
+        std::lock_guard<std::mutex> lock(MbsfnFrameProcessor::_delivery_mutex);
+          MbsfnFrameProcessor::_delivery_queue.push(
+                    {MbsfnFrameProcessor::PendingPdu::Type::Tick, 0, 0, 0, 0, {}});
+    }
+    MbsfnFrameProcessor::_delivery_cv.notify_one();
+    */
+    if (tick%measurement_interval == 0/* false*/) {
+      auto t1 = std::chrono::high_resolution_clock::now();
+      auto t2 = t1;
+ 
+
       // It's time to output rx info to the measurement file and to syslog.
       // Collect the relevant info and write it out.
       std::vector<std::string> cols;
@@ -612,7 +696,7 @@ auto main(int argc, char **argv) -> int {
         cols.push_back(std::to_string((float)rest_handler.cinr_db()));
 
         // Wait to finish and lock, we don't want to update total and errors independently. Yes, it's a blocking solution, but, what other way is possible?
-        cas_processor.lock();
+   //     cas_processor.lock();
         
         spdlog::info("PDSCH: MCS {}, BLER {}",
             rest_handler._pdsch.mcs,
@@ -621,23 +705,34 @@ auto main(int argc, char **argv) -> int {
         cols.push_back(std::to_string(rest_handler._pdsch.mcs));
         cols.push_back(std::to_string(((rest_handler._pdsch.errors * 1.0) / (rest_handler._pdsch.total * 1.0))));
 
-        pdsch_bler_global += rest_handler._pdsch.errors;
+   /*     pdsch_bler_global += rest_handler._pdsch.errors;
         pdsch_total_global += rest_handler._pdsch.total;
-        rest_handler._pdsch.errors = 0;
-        rest_handler._pdsch.total = 0;
+        */
+
+        std::tie(pdsch_bler_global, pdsch_total_global) =
+              rest_handler._pdsch.snapshot_and_reset();
+
+    //    rest_handler._pdsch.errors = 0;
+    //    rest_handler._pdsch.total = 0;
         // We are done with the CAS
-        cas_processor.unlock();
+   //     cas_processor.unlock();
         
         // Wait for all the mbsfn processors to finish, to avoid having an update on total or errors while accesing to the values that leads to having a wrong BLER.
-        for (int i = 0; i < thread_cnt; i++) {
-            mbsfn_processors[i]->lock();
-        }
+   //     for (int i = 0; i < thread_cnt; i++) {
+   //         mbsfn_processors[i]->lock();
+   //     }
+
+
+        auto [mcch_bler_iter, mcch_total_iter] = rest_handler._mcch.snapshot_and_reset();
+
+        mcch_bler_global += mcch_bler_iter;
+        mcch_total_global += mcch_total_iter;
         spdlog::info("MCCH: MCS {}, BLER {}",
             rest_handler._mcch.mcs,
-            ((rest_handler._mcch.errors > 0 && rest_handler._mcch.total > 0) ? (rest_handler._mcch.errors * 1.0) / (rest_handler._mcch.total * 1.0) : 0));
+            ((mcch_bler_iter > 0 && mcch_total_global > 0) ? (mcch_bler_iter * 1.0) / (mcch_total_global * 1.0) : 0));
 
         cols.push_back(std::to_string(rest_handler._mcch.mcs));
-        cols.push_back(std::to_string(((rest_handler._mcch.errors * 1.0) / (rest_handler._mcch.total * 1.0))));
+        cols.push_back(std::to_string(((mcch_bler_iter * 1.0) / (mcch_total_global * 1.0))));
 
         cols.push_back(std::to_string(tti)); // Current TTI
         cols.emplace_back(std::string("")); // Blank to maintain the column, only used when desync.
@@ -647,17 +742,18 @@ auto main(int argc, char **argv) -> int {
         int mch_idx = 0;
         std::for_each(std::begin(mch_info), std::end(mch_info), [&cols, &mch_idx, &rest_handler, &mch_bler_global, &mch_total_global](Phy::mch_info_t const& mch) {
 
+            auto [mch_bler_iter, mch_total_iter] = rest_handler._mch[mch_idx].snapshot_and_reset();
             spdlog::info("MCH {}: MCS {}, BLER {}",
                 mch_idx,
                 mch.mcs,
-                ((rest_handler._mch[mch_idx].errors > 0 && rest_handler._mch[mch_idx].total > 0) ? (rest_handler._mch[mch_idx].errors * 1.0) / (rest_handler._mch[mch_idx].total * 1.0) : 0));
+                ((mch_bler_iter > 0 && mch_total_iter > 0) ? (mch_bler_iter * 1.0) / (mch_total_iter * 1.0) : 0));
 
             cols.push_back(std::to_string(mch_idx));
             cols.push_back(std::to_string(mch.mcs));
-            cols.push_back(std::to_string((rest_handler._mch[mch_idx].errors * 1.0) / (rest_handler._mch[mch_idx].total * 1.0)));
+            cols.push_back(std::to_string((mch_bler_iter * 1.0) / (mch_total_iter * 1.0)));
 
             int mtch_idx = 0;
-            std::for_each(std::begin(mch.mtchs), std::end(mch.mtchs), [&mtch_idx, &mch_bler_global, &mch_total_global](Phy::mtch_info_t const& mtch) {
+            std::for_each(std::begin(mch.mtchs), std::end(mch.mtchs), [&mtch_idx/*, &mch_bler_global, &mch_total_global*/](Phy::mtch_info_t const& mtch) {
               spdlog::info("    MTCH {}: LCID {}, TMGI 0x{}, {}",
                 mtch_idx,
                 mtch.lcid,
@@ -666,21 +762,26 @@ auto main(int argc, char **argv) -> int {
               mtch_idx++;
                 });
 
-              mch_bler_global  += rest_handler._mch[mch_idx].errors;
+             /* mch_bler_global  += rest_handler._mch[mch_idx].errors;
               mch_total_global += rest_handler._mch[mch_idx].total;
-              rest_handler._mch[mch_idx].errors = 0;
-              rest_handler._mch[mch_idx].total = 0;
+              */
+
+              mch_bler_global  += mch_bler_iter;
+              mch_total_global += mch_total_iter;
+
+//              rest_handler._mch[mch_idx].errors = 0;
+//              rest_handler._mch[mch_idx].total = 0;
               mch_idx++;
             });
 
-        mcch_bler_global += rest_handler._mcch.errors;
+/*        mcch_bler_global += rest_handler._mcch.errors;
         mcch_total_global += rest_handler._mcch.total;
         rest_handler._mcch.errors = 0;
-        rest_handler._mcch.total = 0;
+        rest_handler._mcch.total = 0;*/
         // We can unlock cas and mbsfn processor at this point, every variable has been saved in the rest_handler.
-        for (int i = 0; i < thread_cnt; i++) {
-          mbsfn_processors[i]->unlock();
-        }
+//        for (int i = 0; i < thread_cnt; i++) {
+//          mbsfn_processors[i]->unlock();
+//        }
       } else if (state == syncing) { // In syncing and searching states we place in every row and column NaN, this way is easier to process after, since every time measured theres always a row in the csv.
         cols.emplace_back(std::string("NOT SYNC - SYNCING...")); 
         cols.emplace_back(std::string("nan")); 
@@ -711,7 +812,7 @@ auto main(int argc, char **argv) -> int {
       if (enable_measurement_file) {
         measurement_file.WriteLogValues(cols);
       }
-      measurements++;
+//      measurements++;
       
       spdlog::info("------ Global statistics ------ \n\t\tMCH BLER {}, \n\t\tMCH TOTAL ERRORS {}, \n\t\tMCCH BLER: {}, \n\t\tPDSCH BLER: {}, \n\t\tSYNC LOSSES: {}, \n\t\tSF PROCESSED: {}", 
           ((mch_bler_global > 0 && mch_total_global > 0) ? (mch_bler_global * 1.0) / (mch_total_global * 1.0) : 0),
@@ -723,13 +824,28 @@ auto main(int argc, char **argv) -> int {
       
       spdlog::info("Total subframe lost {}, sync losses {}.", lost_subframes, sync_losses);
 
+      t2 = std::chrono::high_resolution_clock::now();
+      spdlog::info("We lasted {} microseconds taking measurements.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
     }
   }
 
   // Main loop ended by signal. Free the MBSFN processors, and bail.
-  for (int i = 0; i < thread_cnt; i++) {
+  sdr.stop();
+//  rlc.stop();
+//  pdcp.stop();
+  rest_handler.stop();
+  //gw.stop();
+  //phy.stop();
+  pool.clear();
+  pool.join();
+  //delete(cas_processor);
+  
+  for (size_t i = 0; i < thread_cnt; i++) {
     delete( mbsfn_processors[i] );
   }
-exit:
+
+  } catch (...) {
+    exit(1);
+  }
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,7 +173,7 @@ static Config cfg;  /**< Global configuration object. */
 
 static unsigned sample_rate = 7680000;  /**< Sample rate of the SDR */
 static unsigned search_sample_rate = 7680000;  /**< Sample rate of the SDR */
-static unsigned frequency = 667000000;  /**< Center freqeuncy the SDR is tuned to */
+static unsigned frequency = 667000000;  /**< Center frequency the SDR is tuned to */
 static uint32_t bandwidth = 10000000;   /**< Low pass filter bandwidth for the SDR */
 static double gain = 0.9;               /**< Overall system gain for the SDR */
 static std::string antenna = "LNAW";    /**< Antenna input to be used */
@@ -365,19 +365,7 @@ auto main(int argc, char **argv) -> int {
   }
 
 
-  // Configurar sink de srslog — redirigir a stdout
- /* auto* log_sink = srslog::create_stdout_sink();
-  if (!log_sink) {
-  spdlog::error("Failed to create srslog stdout sink");
-  exit(1);
-  }
-  srslog::log_channel* chan = srslog::create_log_channel("main_channel", *log_sink);
-  srslog::set_default_sink(*log_sink);
-  
- // Arrancar el backend de srslog — SIN esto ningún log aparece
-  srslog::init();
-  */
-  // Configure srsLTE logging
+  // Configure srsRAN logging
  auto& mac_log = srslog::fetch_basic_logger("MAC", false);
   mac_log.set_level(srs_level);
  auto& phy_log = srslog::fetch_basic_logger("PHY", false);
@@ -419,10 +407,8 @@ auto main(int argc, char **argv) -> int {
   }
 
 
-//  for (auto& p : mbsfn_processors)
-//  {
-//  }
   rest_handler.start(); // Start the listener, we need to do it after storing the cas into the rest_handler, otherwise we will get segfault.
+  
   // Start receiving sample data
   sdr.start();
 
@@ -480,30 +466,27 @@ auto main(int argc, char **argv) -> int {
 
               // ...adjust the SDR's sample rate to fit the wider MBSFN bandwidth...
               unsigned new_srate = srsran_sampling_freq_hz(mbsfn_nof_prb);
-              spdlog::info("Setting sample rate {} Mhz for MBSFN with {} PRB / {} Mhz channel width", new_srate/1000000.0, mbsfn_nof_prb,
-                  mbsfn_nof_prb * 0.2);
-              sdr.stop();
-
-              bandwidth = (mbsfn_nof_prb * 200000) * 1.2;
-              sdr.tune(frequency, new_srate, bandwidth, gain, antenna, use_agc);
-
+              bandwidth = (mbsfn_nof_prb * 200000);
               // ... configure the PHY and CAS processor to decode a narrow CAS and wider MBSFN, and move back to syncing state
               // after reconfiguring and restarting the SDR.
               phy.set_cell();
               cas_processor.set_cell(phy.cell());
 
-              sdr.start();
+              if (new_srate != sample_rate) {
+                spdlog::info("Setting sample rate {} Mhz for MBSFN with {} PRB / {} Mhz channel width", new_srate/1000000.0, mbsfn_nof_prb,
+                    mbsfn_nof_prb * 0.2);
+                sdr.stop();
+                sdr.tune(frequency, new_srate, bandwidth, gain, antenna, use_agc);
+                sdr.start();
+              }
               spdlog::info("Synchronizing subframe after PRB extension");
-              //MbsfnFrameProcessor::stop_delivery_worker();
               state = syncing;
             }
           } else {
             // Failed to receive data, or sync lost. Go back to searching state.
             spdlog::warn("Synchronization lost while processing. Going back to searching state.");
             sync_losses++;
-//            MbsfnFrameProcessor::stop_delivery_worker();
             state = syncing;
-//            auto t2 = std::chrono::high_resolution_clock::now();
           }
         } else {
           // All other frames in FeMBMS dedicated mode are MBSFN frames.
@@ -514,68 +497,42 @@ auto main(int argc, char **argv) -> int {
           auto t1 = std::chrono::high_resolution_clock::now();
           auto t2 = t1;
 
-        //  while (true) // Let's see which mbsfn processor is available
-        //  {
-        //    mb_idx = static_cast<int>((++mb_idx) % thread_cnt);
-          //  spdlog::debug("Probing mbs_processor {}.", mb_idx);
-            auto* proc = free_processors.pop();//mbsfn_processors[mb_idx]; // Grab a processor
+          auto* proc = free_processors.pop();//mbsfn_processors[mb_idx]; // Grab a processor
 
-//            if (/*auto buf = proc->try_get_rx_buffer_and_lock()*/ !proc->busy.exchange(true, std::memory_order_acquire)) { // Try to catch mbsfn processor i
-          //  spdlog::info("Grab processor {}.", proc->get_id());
-              // If its available we can launch it
-              if (!restart && phy.get_next_frame(proc->get_rx_buffer(), proc->rx_buffer_size())) {
-                t2 = std::chrono::high_resolution_clock::now();
-                if (phy.mcch_configured() && phy.is_mbsfn_subframe(tti)) {
-                  // If data frm SIB1/SIB13 has been received in CAS, configure the processors accordingly
-                  if (!/*mbsfn_processors[mb_idx]*/proc->mbsfn_configured()) {
-                    srsran_scs_t scs = SRSRAN_SCS_15KHZ;
-                    switch (phy.mbsfn_subcarrier_spacing()) {
-                      case Phy::SubcarrierSpacing::df_15kHz:  scs = SRSRAN_SCS_15KHZ; break;
-                      case Phy::SubcarrierSpacing::df_7kHz5:  scs = SRSRAN_SCS_7KHZ5; break;
-                      case Phy::SubcarrierSpacing::df_1kHz25: scs = SRSRAN_SCS_1KHZ25; break;
-                    }
-                    auto cell = phy.cell();
-                    cell.nof_prb = cell.mbsfn_prb;
-                    /*mbsfn_processors[mb_idx]->set_cell(cell);
-                    mbsfn_processors[mb_idx]->configure_mbsfn(phy.mbsfn_area_id(), scs);
-                    */
-                    proc->set_cell(cell);
-                    proc->configure_mbsfn(phy.mbsfn_area_id(), scs);
-
-                  }
-          //  spdlog::info("Before push.");
-                  pool.push([ObjectPtr = proc /*mbsfn_processors[mb_idx]*/, tti, &free_processors] {
-          //  spdlog::info("Lnching process {}.", ObjectPtr->get_id());
-                    ObjectPtr->process(tti);
-                    //proc->process(tti);
-         //   spdlog::info("Queueing processor {}.", ObjectPtr->get_id());
-                    free_processors.push(ObjectPtr);
-                    //ObjectPtr->unlock();
-                  });
-                } else {
-                  // Nothing to do yet, we lack the data from SIB1/SIB13
-                  // Discard the samples and unlock the processor.
-                //  mbsfn_processors[mb_idx]->unlock();
-                  //proc->unlock();
-                  //proc->release();
-                  free_processors.push(proc); // Back to the queue
+          // If its available we can launch it
+          if (!restart && phy.get_next_frame(proc->get_rx_buffer(), proc->rx_buffer_size())) {
+            t2 = std::chrono::high_resolution_clock::now();
+            if (phy.mcch_configured() && phy.is_mbsfn_subframe(tti)) {
+              // If data frm SIB1/SIB13 has been received in CAS, configure the processors accordingly
+              if (!/*mbsfn_processors[mb_idx]*/proc->mbsfn_configured()) {
+                srsran_scs_t scs = SRSRAN_SCS_15KHZ;
+                switch (phy.mbsfn_subcarrier_spacing()) {
+                  case Phy::SubcarrierSpacing::df_15kHz:  scs = SRSRAN_SCS_15KHZ; break;
+                  case Phy::SubcarrierSpacing::df_7kHz5:  scs = SRSRAN_SCS_7KHZ5; break;
+                  case Phy::SubcarrierSpacing::df_1kHz25: scs = SRSRAN_SCS_1KHZ25; break;
                 }
-              } else {
-                // Failed to receive data, or sync lost. Go back to searching state.
-                spdlog::warn("Synchronization lost while processing. Going back to searching state, we were waiting {} microseconds.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
-                sync_losses++; 
-//                MbsfnFrameProcessor::stop_delivery_worker();
-                state = syncing;
-                free_processors.push(proc); // Back to the queue
+                auto cell = phy.cell();
+                cell.nof_prb = cell.mbsfn_prb;
+                proc->set_cell(cell);
+                proc->configure_mbsfn(phy.mbsfn_area_id(), scs);
+
               }
-              //mb_idx = static_cast<int>((mb_idx + 1) % thread_cnt);
-            //  break; // Stops searching in this iteration for an available processor
- //           }
-            
-         // }
-        //  if (std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() > 2000)
-           // spdlog::info("We waited {} microseconds for mbs_processor {}.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count(), proc->get_id());
-//          mb_idx = static_cast<int>((mb_idx + 1) % thread_cnt);
+              pool.push([ObjectPtr = proc /*mbsfn_processors[mb_idx]*/, tti, &free_processors] {
+                ObjectPtr->process(tti);
+                free_processors.push(ObjectPtr);
+              });
+            } else {
+              // Nothing to do yet, we lack the data from SIB1/SIB13
+              // Discard the samples and unlock the processor.
+              free_processors.push(proc); // Back to the queue
+            }
+          } else {
+            // Failed to receive data, or sync lost. Go back to searching state.
+            spdlog::warn("Synchronization lost while processing. Going back to searching state, we were waiting {} microseconds.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
+            sync_losses++; 
+            state = syncing;
+            free_processors.push(proc); // Back to the queue
+          }
         }
       }
       break;
@@ -593,7 +550,6 @@ auto main(int argc, char **argv) -> int {
 
         // In searching state, clear the receive buffer and try to find a cell at the configured frequency and synchronize with it
         restart = false;
-       // sdr.clear_buffer();
         bool cell_found = phy.cell_search();
         if (cell_found) {
           // A cell has been found. We now know the required number of PRB = bandwidth of the carrier. Set the approproiate
@@ -610,21 +566,21 @@ auto main(int argc, char **argv) -> int {
           } else {
             // When decoding from the air, configure the SDR accordingly
             unsigned new_srate = srsran_sampling_freq_hz(cas_nof_prb);
-            spdlog::info("Setting sample rate {} Mhz for {} PRB / {} Mhz channel width", new_srate/1000000.0, phy.nr_prb(),
-                phy.nr_prb() * 0.2);
-            sdr.stop();
-            sdr.clear_buffer();
-            bandwidth = (cas_nof_prb * 200000) * 1.2;
-            sdr.tune(frequency, new_srate, bandwidth, gain, antenna, use_agc);
-            //sleep(1);
-
-            sdr.start();
+            if (new_srate != sample_rate) {
+	      sample_rate = new_srate;
+	      spdlog::info("Setting sample rate {} Mhz for {} PRB / {} Mhz channel width", new_srate/1000000.0, phy.nr_prb(),
+		  phy.nr_prb() * 0.2);
+	      sdr.stop();
+	      bandwidth = (cas_nof_prb * 200000);
+	      sdr.tune(frequency, new_srate, bandwidth, gain, antenna, use_agc);
+	      sdr.start();
+            }
           }
           spdlog::debug("Synchronizing subframe");
           // ... and move to syncing state.
           state = syncing;
         } else {
-          //sleep(1);
+          // Do nothing...
         }
       } 
       break;
@@ -648,17 +604,12 @@ auto main(int argc, char **argv) -> int {
           // Set the cell parameters in the CAS processor, and set started to true
           cas_processor.set_cell(phy.cell());
 
-//          for (int i = 0; i < thread_cnt; i++) {
-            //mbsfn_processors[i]->unlock();
-//            mbsfn_processors[i]->release();
-//          }
           cas_processor.unlock(); // We need to unlock because we felt here from processing after calling get_rx_buffer_and_lock()
 
           // Get the initial TTI / subframe ID (= system frame number * 10 + subframe number)
           tti = phy.tti();
           // Reset the RRC
           rrc.reset();
-//          MbsfnFrameProcessor::start_delivery_worker(rlc, phy/*, timers*/);
           // Ready to receive actual data. Go to processing state.
           state = processing;
 
@@ -674,13 +625,6 @@ auto main(int argc, char **argv) -> int {
     
     tick++;
     timers.step_all();
-   /* {
-        std::lock_guard<std::mutex> lock(MbsfnFrameProcessor::_delivery_mutex);
-          MbsfnFrameProcessor::_delivery_queue.push(
-                    {MbsfnFrameProcessor::PendingPdu::Type::Tick, 0, 0, 0, 0, {}});
-    }
-    MbsfnFrameProcessor::_delivery_cv.notify_one();
-    */
     if (tick%measurement_interval == 0/* false*/) {
       auto t1 = std::chrono::high_resolution_clock::now();
       auto t2 = t1;
@@ -695,9 +639,6 @@ auto main(int argc, char **argv) -> int {
         spdlog::info("CINR {:.2f} dB", rest_handler.cinr_db() );
         cols.push_back(std::to_string((float)rest_handler.cinr_db()));
 
-        // Wait to finish and lock, we don't want to update total and errors independently. Yes, it's a blocking solution, but, what other way is possible?
-   //     cas_processor.lock();
-        
         spdlog::info("PDSCH: MCS {}, BLER {}",
             rest_handler._pdsch.mcs,
             ((rest_handler._pdsch.errors > 0 && rest_handler._pdsch.total > 0) ? (rest_handler._pdsch.errors * 1.0) / (rest_handler._pdsch.total * 1.0) : 0));
@@ -705,23 +646,8 @@ auto main(int argc, char **argv) -> int {
         cols.push_back(std::to_string(rest_handler._pdsch.mcs));
         cols.push_back(std::to_string(((rest_handler._pdsch.errors * 1.0) / (rest_handler._pdsch.total * 1.0))));
 
-   /*     pdsch_bler_global += rest_handler._pdsch.errors;
-        pdsch_total_global += rest_handler._pdsch.total;
-        */
-
         std::tie(pdsch_bler_global, pdsch_total_global) =
               rest_handler._pdsch.snapshot_and_reset();
-
-    //    rest_handler._pdsch.errors = 0;
-    //    rest_handler._pdsch.total = 0;
-        // We are done with the CAS
-   //     cas_processor.unlock();
-        
-        // Wait for all the mbsfn processors to finish, to avoid having an update on total or errors while accesing to the values that leads to having a wrong BLER.
-   //     for (int i = 0; i < thread_cnt; i++) {
-   //         mbsfn_processors[i]->lock();
-   //     }
-
 
         auto [mcch_bler_iter, mcch_total_iter] = rest_handler._mcch.snapshot_and_reset();
 
@@ -762,26 +688,11 @@ auto main(int argc, char **argv) -> int {
               mtch_idx++;
                 });
 
-             /* mch_bler_global  += rest_handler._mch[mch_idx].errors;
-              mch_total_global += rest_handler._mch[mch_idx].total;
-              */
-
               mch_bler_global  += mch_bler_iter;
               mch_total_global += mch_total_iter;
 
-//              rest_handler._mch[mch_idx].errors = 0;
-//              rest_handler._mch[mch_idx].total = 0;
               mch_idx++;
             });
-
-/*        mcch_bler_global += rest_handler._mcch.errors;
-        mcch_total_global += rest_handler._mcch.total;
-        rest_handler._mcch.errors = 0;
-        rest_handler._mcch.total = 0;*/
-        // We can unlock cas and mbsfn processor at this point, every variable has been saved in the rest_handler.
-//        for (int i = 0; i < thread_cnt; i++) {
-//          mbsfn_processors[i]->unlock();
-//        }
       } else if (state == syncing) { // In syncing and searching states we place in every row and column NaN, this way is easier to process after, since every time measured theres always a row in the csv.
         cols.emplace_back(std::string("NOT SYNC - SYNCING...")); 
         cols.emplace_back(std::string("nan")); 
@@ -825,20 +736,17 @@ auto main(int argc, char **argv) -> int {
       spdlog::info("Total subframe lost {}, sync losses {}.", lost_subframes, sync_losses);
 
       t2 = std::chrono::high_resolution_clock::now();
-      spdlog::info("We lasted {} microseconds taking measurements.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
+      spdlog::debug("We lasted {} microseconds taking measurements.", std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count());
     }
   }
 
   // Main loop ended by signal. Free the MBSFN processors, and bail.
   sdr.stop();
-//  rlc.stop();
-//  pdcp.stop();
+  rlc.stop();
+  pdcp.stop();
   rest_handler.stop();
-  //gw.stop();
-  //phy.stop();
   pool.clear();
   pool.join();
-  //delete(cas_processor);
   
   for (size_t i = 0; i < thread_cnt; i++) {
     delete( mbsfn_processors[i] );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,9 +54,7 @@ using libconfig::Config;
 using libconfig::FileIOException;
 using libconfig::ParseException;
 
-using std::placeholders::_1;
-using std::placeholders::_2;
-using std::placeholders::_3;
+using namespace std::placeholders;
 
 static void print_version(FILE *stream, struct argp_state *state);
 void (*argp_program_version_hook)(FILE *, struct argp_state *) = print_version;
@@ -334,6 +332,27 @@ auto main(int argc, char **argv) -> int {
   cfg.lookupValue("modem.measurement_file.enabled", enable_measurement_file);
   MeasurementFileWriter measurement_file(cfg);
 
+  auto srs_level = srslog::basic_levels::none;
+  switch (arguments.srs_log_level) {
+    case 0: srs_level = srslog::basic_levels::debug; break;
+    case 1: srs_level = srslog::basic_levels::info; break;
+    case 2: srs_level = srslog::basic_levels::warning; break;
+    case 3: srs_level = srslog::basic_levels::error; break;
+    case 4: 
+    default: srs_level = srslog::basic_levels::none; break;
+  }
+
+  // Configure srsRAN logging
+ auto& mac_log = srslog::fetch_basic_logger("MAC", false);
+  mac_log.set_level(srs_level);
+ auto& phy_log = srslog::fetch_basic_logger("PHY", false);
+  phy_log.set_level(srs_level);
+ auto& rlc_log = srslog::fetch_basic_logger("RLC", false);
+  rlc_log.set_level(srs_level);
+ auto& asn1_log = srslog::fetch_basic_logger("ASN1", false);
+  asn1_log.set_level(srs_level);
+
+
   // Create the layer components: Phy, RLC, RRC and GW
   Phy phy(
       std::bind(&SdrReader::get_samples, &sdr, _1, _2, _3),  // NOLINT
@@ -354,26 +373,6 @@ auto main(int argc, char **argv) -> int {
 
   rlc.init(&pdcp, &rrc, &timers, 0 /* RB_ID_SRB0 */);
   pdcp.init(&rlc, &rrc,  &gw);
-
-  auto srs_level = srslog::basic_levels::none;
-  switch (arguments.srs_log_level) {
-    case 0: srs_level = srslog::basic_levels::debug; break;
-    case 1: srs_level = srslog::basic_levels::info; break;
-    case 2: srs_level = srslog::basic_levels::warning; break;
-    case 3: srs_level = srslog::basic_levels::error; break;
-    case 4: srs_level = srslog::basic_levels::none; break;
-  }
-
-
-  // Configure srsRAN logging
- auto& mac_log = srslog::fetch_basic_logger("MAC", false);
-  mac_log.set_level(srs_level);
- auto& phy_log = srslog::fetch_basic_logger("PHY", false);
-  phy_log.set_level(srs_level);
- auto& rlc_log = srslog::fetch_basic_logger("RLC", false);
-  rlc_log.set_level(srs_level);
- auto& asn1_log = srslog::fetch_basic_logger("ASN1", false);
-  asn1_log.set_level(srs_level);
 
 
   state_t state = searching;
@@ -429,7 +428,7 @@ auto main(int argc, char **argv) -> int {
 
   float measurement_interval_f = 5;
   cfg.lookupValue("modem.measurement_file.interval_secs", measurement_interval_f);
-  uint32_t measurement_interval = measurement_interval_f * 1000;
+  uint32_t measurement_interval = static_cast<uint32_t>(measurement_interval_f) * 1000;
   uint32_t tick = 0;
 
   // Initial state: searching a cell
@@ -661,7 +660,7 @@ auto main(int argc, char **argv) -> int {
         cols.push_back(std::to_string(((mcch_bler_iter * 1.0) / (mcch_total_global * 1.0))));
 
         cols.push_back(std::to_string(tti)); // Current TTI
-        cols.emplace_back(std::string("")); // Blank to maintain the column, only used when desync.
+        cols.emplace_back(""); // Blank to maintain the column, only used when desync.
         cols.push_back(std::to_string(lost_subframes)); // Total amount of lost subframes
 
         auto mch_info = phy.mch_info();
@@ -694,30 +693,30 @@ auto main(int argc, char **argv) -> int {
               mch_idx++;
             });
       } else if (state == syncing) { // In syncing and searching states we place in every row and column NaN, this way is easier to process after, since every time measured theres always a row in the csv.
-        cols.emplace_back(std::string("NOT SYNC - SYNCING...")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
+        cols.emplace_back("NOT SYNC - SYNCING..."); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
         cols.push_back(std::to_string(sync_losses)); 
         cols.push_back(std::to_string(lost_subframes));
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
 
       } else {
-        cols.emplace_back(std::string("SEARCHING FOR A CELL...")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string(""));
+        cols.emplace_back("SEARCHING FOR A CELL..."); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("");
         cols.push_back(std::to_string(lost_subframes));
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
-        cols.emplace_back(std::string("nan")); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
+        cols.emplace_back("nan"); 
       }
     
       if (enable_measurement_file) {

--- a/supporting_files/5gmag-rt.conf
+++ b/supporting_files/5gmag-rt.conf
@@ -1,0 +1,82 @@
+modem: {
+  sdr: {
+    center_frequency_hz = 619500000L;
+
+// Uncomment the needed sampling rate. 
+//    search_sample_rate_hz = 3840000; // 3 MHz 
+//    search_sample_rate_hz = 7680000; // 5 MHz
+    search_sample_rate_hz = 15360000; // 6, 7, 8, 10 MHz
+
+    normalized_gain = 45.0;
+    device_args = "driver=uhd,master_clock_rate=30.72e6,recv_buff_size=4000000,num_recv_frames=1544,recv_frame_size=10560,WIRE=sc16";
+    antenna = "RX2";
+    rx_channels = 1;
+    ringbuffer_size_ms = 100;
+    reader_thread_priority_rt = 70;
+  }
+
+  phy: {
+    threads = 1; // One thread should be enough for a relative modern CPU. If you increase the number of threads you need also to increase ringbuffer_size_ms accordingly.
+    thread_priority_rt = 50;
+    main_thread_priority_rt = 60;
+    allow_rrc_sn_across_periods = false;
+  }
+
+  restful_api: {
+    uri: "http://0.0.0.0:3010/modem-api/";
+    cert: "/usr/share/5gmag-rt/cert.pem";
+    key: "/usr/share/5gmag-rt/key.pem";
+    api_key:
+    {
+      enabled: false;
+      key: "106cd60-76c8-4c37-944c-df21aa690c1e";
+    }
+  }
+
+  measurement_file: {
+    enabled: false;
+    file_path: "/tmp/modem_measurements.csv";
+    interval_secs: 1.0;      
+    gpsd:
+    {
+      enabled: false;
+      host: "localhost";
+      port: "2947";
+    }
+  }
+}
+
+mw: {
+  cache: { 
+    max_file_age: 30;    /* seconds */
+    max_total_size: 512; /* megabyte */
+  }
+  http_server: {
+    uri: "http://0.0.0.0:3020/";
+    api_path: "mw-api";
+    cert: "/usr/share/5gmag-rt/cert.pem";
+    key: "/usr/share/5gmag-rt/key.pem";
+    api_key:
+    {
+      enabled: false;
+      key: "106cd60-76c8-4c37-944c-df21aa690c1e";
+    }
+  }
+  control_system: {
+    enabled: false;
+    interval: 20; //seconds
+    endpoint: "https://5gbc.ors-aws.cloud/obeca-api";
+  }
+  seamless_switching: {
+    enabled: false;
+    truncate_cdn_playlist_segments: 3
+  }
+  bootstrap_format: "";
+  local_service: {
+    enabled: false;
+    bootstrap_file: "";
+    mcast_address: "238.1.1.95:40085";
+    lcid: 1;
+    tmgi: "00000009f165";
+  }
+}


### PR DESCRIPTION
This pull request contains the new code for the support of the release 16 features, detection and decodification of PBCH repetition at the CAS, aggregation level 16, and decodification of CFI from the MIB.

This update can detect is the receiving signal is release 16 or not, looking for the repetition of the PBCH, so it is automatic, there is no need to flag the version of the signal release.

This has been compiled with the following compilers, gcc 9, 10, and 13,  and clang 10 and 16.

Also I've tested it with the sample files provided [here](https://hub.5g-mag.com/Getting-Started/pages/lte-based-5g-broadcast/additional/sample-files.html) at the 5G MAG, with all bandwidths and with the release 16 ones.

The only test remaining is to validate it with a live signal. I don't know if the people from RAI or ORS can do the test. I don't have any 5GB rel-16 transmitter at the moment.